### PR TITLE
handle appli=16 (users.activity) webhooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ env.prod.sh
 node_modules
 .DS_Store
 /withoutings
+.context/
+.worktrees/

--- a/pkg/withoutings/adapter/withings/measure-v2-getactivity.go
+++ b/pkg/withoutings/adapter/withings/measure-v2-getactivity.go
@@ -1,0 +1,58 @@
+package withings
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/roessland/withoutings/pkg/logging"
+	"github.com/roessland/withoutings/pkg/withoutings/domain/withings"
+	"io"
+	"net/http"
+)
+
+func (c *HTTPClient) MeasureGetactivity(ctx context.Context, accessToken string, params withings.MeasureGetactivityParams) (*withings.MeasureGetactivityResponse, error) {
+	return c.WithAccessToken(accessToken).MeasureGetactivity(ctx, params)
+}
+
+// NewMeasureGetactivityRequest creates a new MeasureGetactivity request.
+func (c *HTTPClient) NewMeasureGetactivityRequest(params withings.MeasureGetactivityParams) (*http.Request, error) {
+	return c.NewRequest("/v2/measure", params, nil)
+}
+
+// MeasureGetactivity gets daily aggregated activity data
+func (c *AuthenticatedClient) MeasureGetactivity(ctx context.Context, params withings.MeasureGetactivityParams) (*withings.MeasureGetactivityResponse, error) {
+	log := logging.MustGetLoggerFromContext(ctx)
+	req, err := c.NewMeasureGetactivityRequest(params)
+	if err != nil {
+		return nil, err
+	}
+	httpResp, err := c.WithAccessToken(c.AccessToken).Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	var resp withings.MeasureGetactivityResponse
+
+	resp.Raw, err = io.ReadAll(httpResp.Body)
+	if err != nil {
+		log.WithField("event", "error.MeasureGetactivity.readbody.failed").
+			WithError(err).
+			Error()
+		return nil, err
+	}
+
+	err = json.Unmarshal(resp.Raw, &resp)
+	if err != nil {
+		log.WithField("response_body", string(resp.Raw)).
+			WithField("event", "error.MeasureGetactivity.unmarshal.failed").
+			WithError(err).
+			Error()
+		return nil, err
+	}
+
+	if resp.Status != 0 {
+		return &resp, withings.APIError(resp.Status)
+	}
+
+	return &resp, nil
+}

--- a/pkg/withoutings/adapter/withings/measure-v2-getintradayactivity.go
+++ b/pkg/withoutings/adapter/withings/measure-v2-getintradayactivity.go
@@ -1,0 +1,58 @@
+package withings
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/roessland/withoutings/pkg/logging"
+	"github.com/roessland/withoutings/pkg/withoutings/domain/withings"
+	"io"
+	"net/http"
+)
+
+func (c *HTTPClient) MeasureGetintradayactivity(ctx context.Context, accessToken string, params withings.MeasureGetintradayactivityParams) (*withings.MeasureGetintradayactivityResponse, error) {
+	return c.WithAccessToken(accessToken).MeasureGetintradayactivity(ctx, params)
+}
+
+// NewMeasureGetintradayactivityRequest creates a new MeasureGetintradayactivity request.
+func (c *HTTPClient) NewMeasureGetintradayactivityRequest(params withings.MeasureGetintradayactivityParams) (*http.Request, error) {
+	return c.NewRequest("/v2/measure", params, nil)
+}
+
+// MeasureGetintradayactivity gets activity data captured at high frequency
+func (c *AuthenticatedClient) MeasureGetintradayactivity(ctx context.Context, params withings.MeasureGetintradayactivityParams) (*withings.MeasureGetintradayactivityResponse, error) {
+	log := logging.MustGetLoggerFromContext(ctx)
+	req, err := c.NewMeasureGetintradayactivityRequest(params)
+	if err != nil {
+		return nil, err
+	}
+	httpResp, err := c.WithAccessToken(c.AccessToken).Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	var resp withings.MeasureGetintradayactivityResponse
+
+	resp.Raw, err = io.ReadAll(httpResp.Body)
+	if err != nil {
+		log.WithField("event", "error.MeasureGetintradayactivity.readbody.failed").
+			WithError(err).
+			Error()
+		return nil, err
+	}
+
+	err = json.Unmarshal(resp.Raw, &resp)
+	if err != nil {
+		log.WithField("response_body", string(resp.Raw)).
+			WithField("event", "error.MeasureGetintradayactivity.unmarshal.failed").
+			WithError(err).
+			Error()
+		return nil, err
+	}
+
+	if resp.Status != 0 {
+		return &resp, withings.APIError(resp.Status)
+	}
+
+	return &resp, nil
+}

--- a/pkg/withoutings/adapter/withings/measure-v2-getworkouts.go
+++ b/pkg/withoutings/adapter/withings/measure-v2-getworkouts.go
@@ -1,0 +1,58 @@
+package withings
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/roessland/withoutings/pkg/logging"
+	"github.com/roessland/withoutings/pkg/withoutings/domain/withings"
+	"io"
+	"net/http"
+)
+
+func (c *HTTPClient) MeasureGetworkouts(ctx context.Context, accessToken string, params withings.MeasureGetworkoutsParams) (*withings.MeasureGetworkoutsResponse, error) {
+	return c.WithAccessToken(accessToken).MeasureGetworkouts(ctx, params)
+}
+
+// NewMeasureGetworkoutsRequest creates a new MeasureGetworkouts request.
+func (c *HTTPClient) NewMeasureGetworkoutsRequest(params withings.MeasureGetworkoutsParams) (*http.Request, error) {
+	return c.NewRequest("/v2/measure", params, nil)
+}
+
+// MeasureGetworkouts gets workout summaries
+func (c *AuthenticatedClient) MeasureGetworkouts(ctx context.Context, params withings.MeasureGetworkoutsParams) (*withings.MeasureGetworkoutsResponse, error) {
+	log := logging.MustGetLoggerFromContext(ctx)
+	req, err := c.NewMeasureGetworkoutsRequest(params)
+	if err != nil {
+		return nil, err
+	}
+	httpResp, err := c.WithAccessToken(c.AccessToken).Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	var resp withings.MeasureGetworkoutsResponse
+
+	resp.Raw, err = io.ReadAll(httpResp.Body)
+	if err != nil {
+		log.WithField("event", "error.MeasureGetworkouts.readbody.failed").
+			WithError(err).
+			Error()
+		return nil, err
+	}
+
+	err = json.Unmarshal(resp.Raw, &resp)
+	if err != nil {
+		log.WithField("response_body", string(resp.Raw)).
+			WithField("event", "error.MeasureGetworkouts.unmarshal.failed").
+			WithError(err).
+			Error()
+		return nil, err
+	}
+
+	if resp.Status != 0 {
+		return &resp, withings.APIError(resp.Status)
+	}
+
+	return &resp, nil
+}

--- a/pkg/withoutings/adapter/withings/withingstestdata/embed.go
+++ b/pkg/withoutings/adapter/withings/withingstestdata/embed.go
@@ -10,3 +10,21 @@ var Sleepv2GetSuccess []byte
 
 //go:embed withings-resp-measure-getmeas-0-weight.json
 var MeasureGetmeasSuccess []byte
+
+//go:embed withings-resp-measurev2-getactivity-0.json
+var MeasureGetactivitySuccess []byte
+
+//go:embed withings-resp-measurev2-getactivity-0-nodata.json
+var MeasureGetactivityNoData []byte
+
+//go:embed withings-resp-measurev2-getintradayactivity-0.json
+var MeasureGetintradayactivitySuccess []byte
+
+//go:embed withings-resp-measurev2-getintradayactivity-0-nodata.json
+var MeasureGetintradayactivityNoData []byte
+
+//go:embed withings-resp-measurev2-getworkouts-0.json
+var MeasureGetworkoutsSuccess []byte
+
+//go:embed withings-resp-measurev2-getworkouts-0-nodata.json
+var MeasureGetworkoutsNoData []byte

--- a/pkg/withoutings/adapter/withings/withingstestdata/withings-resp-measurev2-getactivity-0-nodata.json
+++ b/pkg/withoutings/adapter/withings/withingstestdata/withings-resp-measurev2-getactivity-0-nodata.json
@@ -1,0 +1,8 @@
+{
+  "status": 0,
+  "body": {
+    "activities": [],
+    "more": false,
+    "offset": 0
+  }
+}

--- a/pkg/withoutings/adapter/withings/withingstestdata/withings-resp-measurev2-getactivity-0.json
+++ b/pkg/withoutings/adapter/withings/withingstestdata/withings-resp-measurev2-getactivity-0.json
@@ -1,0 +1,36 @@
+{
+  "status": 0,
+  "body": {
+    "activities": [
+      {
+        "steps": 0,
+        "distance": 0,
+        "elevation": 0,
+        "soft": 0,
+        "moderate": 0,
+        "intense": 0,
+        "active": 0,
+        "calories": 0,
+        "totalcalories": 1784.49,
+        "hr_average": 0,
+        "hr_min": 0,
+        "hr_max": 0,
+        "hr_zone_0": 0,
+        "hr_zone_1": 0,
+        "hr_zone_2": 0,
+        "hr_zone_3": 0,
+        "deviceid": null,
+        "hash_deviceid": null,
+        "timezone": "Europe/Oslo",
+        "date": "2022-01-26",
+        "modified": 1741817057,
+        "brand": 18,
+        "modelid": -1,
+        "model": null,
+        "is_tracker": false
+      }
+    ],
+    "more": false,
+    "offset": 0
+  }
+}

--- a/pkg/withoutings/adapter/withings/withingstestdata/withings-resp-measurev2-getintradayactivity-0-nodata.json
+++ b/pkg/withoutings/adapter/withings/withingstestdata/withings-resp-measurev2-getintradayactivity-0-nodata.json
@@ -1,0 +1,6 @@
+{
+  "status": 0,
+  "body": {
+    "series": {}
+  }
+}

--- a/pkg/withoutings/adapter/withings/withingstestdata/withings-resp-measurev2-getintradayactivity-0.json
+++ b/pkg/withoutings/adapter/withings/withingstestdata/withings-resp-measurev2-getintradayactivity-0.json
@@ -1,0 +1,17 @@
+{
+  "status": 0,
+  "body": {
+    "series": {
+      "1670945820": {
+        "steps": 13,
+        "duration": 60,
+        "elevation": 0,
+        "distance": 9.364,
+        "calories": 1.849,
+        "model": "Samsung Health tracker",
+        "model_id": 1056,
+        "deviceid": null
+      }
+    }
+  }
+}

--- a/pkg/withoutings/adapter/withings/withingstestdata/withings-resp-measurev2-getworkouts-0-nodata.json
+++ b/pkg/withoutings/adapter/withings/withingstestdata/withings-resp-measurev2-getworkouts-0-nodata.json
@@ -1,0 +1,8 @@
+{
+  "status": 0,
+  "body": {
+    "series": [],
+    "more": false,
+    "offset": 0
+  }
+}

--- a/pkg/withoutings/adapter/withings/withingstestdata/withings-resp-measurev2-getworkouts-0.json
+++ b/pkg/withoutings/adapter/withings/withingstestdata/withings-resp-measurev2-getworkouts-0.json
@@ -1,0 +1,41 @@
+{
+  "status": 0,
+  "body": {
+    "series": [
+      {
+        "id": 2733592612,
+        "category": 1,
+        "timezone": "Europe/Oslo",
+        "model": 1056,
+        "attrib": 7,
+        "startdate": 1650999480,
+        "enddate": 1650999900,
+        "date": "2022-04-26",
+        "deviceid": null,
+        "data": {
+          "calories": 31,
+          "intensity": 30,
+          "manual_distance": 0,
+          "manual_calories": 0,
+          "hr_average": 0,
+          "hr_min": 0,
+          "hr_max": 0,
+          "hr_zone_0": 0,
+          "hr_zone_1": 0,
+          "hr_zone_2": 0,
+          "hr_zone_3": 0,
+          "pause_duration": 0,
+          "steps": 717,
+          "distance": 516,
+          "elevation": 7,
+          "manual_intensity": null,
+          "algo_pause_duration": null,
+          "spo2_average": null
+        },
+        "modified": 1653123216
+      }
+    ],
+    "more": false,
+    "offset": 0
+  }
+}

--- a/pkg/withoutings/app/command/fetch_notification_data.go
+++ b/pkg/withoutings/app/command/fetch_notification_data.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -14,6 +15,29 @@ import (
 	"net/url"
 	"time"
 )
+
+// localDayForAppli16 resolves the user's local-day boundary for an appli=16
+// webhook. It picks the timezone from the first activity row in the
+// Getactivity response (Withings tags every row with a timezone). If no
+// activity row is present or the timezone is missing/unknown, it falls back
+// to UTC.
+func localDayForAppli16(dateStr string, activities []json.RawMessage) (time.Time, *time.Location) {
+	loc := time.UTC
+	for _, raw := range activities {
+		var probe struct {
+			Timezone string `json:"timezone"`
+		}
+		if err := json.Unmarshal(raw, &probe); err != nil || probe.Timezone == "" {
+			continue
+		}
+		if l, err := time.LoadLocation(probe.Timezone); err == nil {
+			loc = l
+			break
+		}
+	}
+	day, _ := time.ParseInLocation("2006-01-02", dateStr, loc)
+	return day, loc
+}
 
 type FetchNotificationData struct {
 	Notification *subscription.Notification
@@ -241,8 +265,7 @@ func (h fetchNotificationDataHandler) getAvailableData16(
 	log := logging.MustGetLoggerFromContext(ctx)
 	log = log.WithField("appli", parsedParams.Appli)
 
-	day, err := time.Parse("2006-01-02", parsedParams.DateStr)
-	if err != nil {
+	if _, err := time.Parse("2006-01-02", parsedParams.DateStr); err != nil {
 		// Treat malformed date as a permanent error: log and drop the
 		// notification rather than letting watermill redeliver indefinitely.
 		log.WithError(err).
@@ -269,12 +292,16 @@ func (h fetchNotificationDataHandler) getAvailableData16(
 		service:   subscription.NotificationDataServiceMeasurev2Getactivity,
 	})
 
-	// The webhook does not carry the user's timezone, so widen the intraday
-	// window to [day-24h, day+48h] (UTC). That covers any local day named by
-	// DateStr regardless of the account's UTC offset (-12..+14).
+	// The webhook doesn't carry timezone, but each activity row in the
+	// Getactivity response does. Use it (DST-safe via AddDate) to compute the
+	// intraday window in the user's local day. Fall back to UTC when the day
+	// has zero activities — those days almost never have intraday samples
+	// either, so the UTC fallback won't drop real data in practice.
+	day, loc := localDayForAppli16(parsedParams.DateStr, getactivityResp.Body.Activities)
 	intradayParams := withings.NewMeasureGetintradayactivityParams()
-	intradayParams.Startdate = day.Add(-24 * time.Hour).Unix()
-	intradayParams.Enddate = day.Add(48 * time.Hour).Unix()
+	intradayParams.Startdate = day.Unix()
+	intradayParams.Enddate = day.AddDate(0, 0, 1).Unix()
+	log = log.WithField("intraday_tz", loc.String())
 	intradayResp, err := h.withingsSvc.MeasureGetintradayactivity(ctx, acc, intradayParams)
 	if err != nil {
 		log.WithError(err).

--- a/pkg/withoutings/app/command/fetch_notification_data.go
+++ b/pkg/withoutings/app/command/fetch_notification_data.go
@@ -124,6 +124,8 @@ func (h fetchNotificationDataHandler) getAvailableData(ctx context.Context, acc 
 		return h.getAvailableData1(ctx, acc, parsedParams)
 	case 4:
 		return h.getAvailableData4(ctx, acc, parsedParams)
+	case 16:
+		return h.getAvailableData16(ctx, acc, parsedParams)
 	case 44:
 		return h.getAvailableData44(ctx, acc, parsedParams)
 	case 50:
@@ -220,6 +222,79 @@ func (h fetchNotificationDataHandler) getAvailableData4(
 			service:   "Measure - Getmeas",
 		},
 	}
+
+	return ad, nil
+}
+
+// getAvailableData16 fetches data from Withings API for appli 16:
+// New activity-related data.
+// The webhook payload uses date=YYYY-MM-DD instead of startdate/enddate.
+func (h fetchNotificationDataHandler) getAvailableData16(
+	ctx context.Context,
+	acc *account.Account,
+	parsedParams subscription.ParsedNotificationParams,
+) (availableDatas, error) {
+	if parsedParams.Appli != 16 {
+		panic("getAvailableData16 called with wrong application ID")
+	}
+
+	log := logging.MustGetLoggerFromContext(ctx)
+	log = log.WithField("appli", parsedParams.Appli)
+
+	day, err := time.Parse("2006-01-02", parsedParams.DateStr)
+	if err != nil {
+		return nil, fmt.Errorf("appli=16: cannot parse date %q as YYYY-MM-DD: %w", parsedParams.DateStr, err)
+	}
+	ymd := day.Format("2006-01-02")
+	ad := availableDatas{}
+
+	getactivityParams := withings.NewMeasureGetactivityParams()
+	getactivityParams.Startdateymd = ymd
+	getactivityParams.Enddateymd = ymd
+	getactivityResp, err := h.withingsSvc.MeasureGetactivity(ctx, acc, getactivityParams)
+	if err != nil {
+		log.WithError(err).
+			WithField("event", "error.command.FetchNotificationData.MeasureGetactivity.failed").
+			Error()
+		return nil, fmt.Errorf("failed to call Withings API MeasureGetactivity: %w", err)
+	}
+	ad = append(ad, availableData{
+		data:      getactivityResp.Raw,
+		fetchedAt: time.Now(),
+		service:   "Measure v2 - Getactivity",
+	})
+
+	intradayParams := withings.NewMeasureGetintradayactivityParams()
+	intradayParams.Startdate = day.UTC().Unix()
+	intradayParams.Enddate = day.UTC().Add(24 * time.Hour).Unix()
+	intradayResp, err := h.withingsSvc.MeasureGetintradayactivity(ctx, acc, intradayParams)
+	if err != nil {
+		log.WithError(err).
+			WithField("event", "error.command.FetchNotificationData.MeasureGetintradayactivity.failed").
+			Error()
+		return nil, fmt.Errorf("failed to call Withings API MeasureGetintradayactivity: %w", err)
+	}
+	ad = append(ad, availableData{
+		data:      intradayResp.Raw,
+		fetchedAt: time.Now(),
+		service:   "Measure v2 - Getintradayactivity",
+	})
+
+	getworkoutsParams := withings.NewMeasureGetworkoutsParams()
+	getworkoutsParams.Startdateymd = ymd
+	getworkoutsParams.Enddateymd = ymd
+	getworkoutsResp, err := h.withingsSvc.MeasureGetworkouts(ctx, acc, getworkoutsParams)
+	if err != nil {
+		log.WithError(err).
+			WithField("event", "error.command.FetchNotificationData.MeasureGetworkouts.failed").
+			Error()
+		return nil, fmt.Errorf("failed to call Withings API MeasureGetworkouts: %w", err)
+	}
+	ad = append(ad, availableData{
+		data:      getworkoutsResp.Raw,
+		fetchedAt: time.Now(),
+		service:   "Measure v2 - Getworkouts",
+	})
 
 	return ad, nil
 }

--- a/pkg/withoutings/app/command/fetch_notification_data.go
+++ b/pkg/withoutings/app/command/fetch_notification_data.go
@@ -69,7 +69,7 @@ func (h fetchNotificationDataHandler) Handle(ctx context.Context, cmd FetchNotif
 			NotificationDataUUID: uuid.New(),
 			NotificationUUID:     cmd.Notification.UUID(),
 			AccountUUID:          cmd.Notification.AccountUUID(),
-			Service:              subscription.NotificationDataService(data.service),
+			Service:              data.service,
 			Data:                 data.data,
 			FetchedAt:            data.fetchedAt,
 		})
@@ -113,7 +113,7 @@ type availableDatas []availableData
 type availableData struct {
 	data      []byte
 	fetchedAt time.Time
-	service   string
+	service   subscription.NotificationDataService
 }
 
 // getAvailableData fetches data from Withings API corresponding to the notification category.
@@ -172,7 +172,7 @@ func (h fetchNotificationDataHandler) getAvailableData1(
 		{
 			data:      getmeasResponse.Raw,
 			fetchedAt: time.Now(),
-			service:   "Measure - Getmeas",
+			service:   subscription.NotificationDataServiceMeasureGetMeas,
 		},
 	}
 
@@ -219,7 +219,7 @@ func (h fetchNotificationDataHandler) getAvailableData4(
 		{
 			data:      getmeasResponse.Raw,
 			fetchedAt: time.Now(),
-			service:   "Measure - Getmeas",
+			service:   subscription.NotificationDataServiceMeasureGetMeas,
 		},
 	}
 
@@ -243,14 +243,19 @@ func (h fetchNotificationDataHandler) getAvailableData16(
 
 	day, err := time.Parse("2006-01-02", parsedParams.DateStr)
 	if err != nil {
-		return nil, fmt.Errorf("appli=16: cannot parse date %q as YYYY-MM-DD: %w", parsedParams.DateStr, err)
+		// Treat malformed date as a permanent error: log and drop the
+		// notification rather than letting watermill redeliver indefinitely.
+		log.WithError(err).
+			WithField("date_str", parsedParams.DateStr).
+			WithField("event", "warn.command.FetchNotificationData.appli16.malformed_date").
+			Warn()
+		return availableDatas{}, nil
 	}
-	ymd := day.Format("2006-01-02")
 	ad := availableDatas{}
 
 	getactivityParams := withings.NewMeasureGetactivityParams()
-	getactivityParams.Startdateymd = ymd
-	getactivityParams.Enddateymd = ymd
+	getactivityParams.Startdateymd = parsedParams.DateStr
+	getactivityParams.Enddateymd = parsedParams.DateStr
 	getactivityResp, err := h.withingsSvc.MeasureGetactivity(ctx, acc, getactivityParams)
 	if err != nil {
 		log.WithError(err).
@@ -261,12 +266,15 @@ func (h fetchNotificationDataHandler) getAvailableData16(
 	ad = append(ad, availableData{
 		data:      getactivityResp.Raw,
 		fetchedAt: time.Now(),
-		service:   "Measure v2 - Getactivity",
+		service:   subscription.NotificationDataServiceMeasurev2Getactivity,
 	})
 
+	// The webhook does not carry the user's timezone, so widen the intraday
+	// window to [day-24h, day+48h] (UTC). That covers any local day named by
+	// DateStr regardless of the account's UTC offset (-12..+14).
 	intradayParams := withings.NewMeasureGetintradayactivityParams()
-	intradayParams.Startdate = day.UTC().Unix()
-	intradayParams.Enddate = day.UTC().Add(24 * time.Hour).Unix()
+	intradayParams.Startdate = day.Add(-24 * time.Hour).Unix()
+	intradayParams.Enddate = day.Add(48 * time.Hour).Unix()
 	intradayResp, err := h.withingsSvc.MeasureGetintradayactivity(ctx, acc, intradayParams)
 	if err != nil {
 		log.WithError(err).
@@ -277,12 +285,12 @@ func (h fetchNotificationDataHandler) getAvailableData16(
 	ad = append(ad, availableData{
 		data:      intradayResp.Raw,
 		fetchedAt: time.Now(),
-		service:   "Measure v2 - Getintradayactivity",
+		service:   subscription.NotificationDataServiceMeasurev2Getintradayactivity,
 	})
 
 	getworkoutsParams := withings.NewMeasureGetworkoutsParams()
-	getworkoutsParams.Startdateymd = ymd
-	getworkoutsParams.Enddateymd = ymd
+	getworkoutsParams.Startdateymd = parsedParams.DateStr
+	getworkoutsParams.Enddateymd = parsedParams.DateStr
 	getworkoutsResp, err := h.withingsSvc.MeasureGetworkouts(ctx, acc, getworkoutsParams)
 	if err != nil {
 		log.WithError(err).
@@ -293,7 +301,7 @@ func (h fetchNotificationDataHandler) getAvailableData16(
 	ad = append(ad, availableData{
 		data:      getworkoutsResp.Raw,
 		fetchedAt: time.Now(),
-		service:   "Measure v2 - Getworkouts",
+		service:   subscription.NotificationDataServiceMeasurev2Getworkouts,
 	})
 
 	return ad, nil
@@ -328,7 +336,7 @@ func (h fetchNotificationDataHandler) getAvailableData44(
 	ad = append(ad, availableData{
 		data:      sleepGetsummaryResponse.Raw,
 		fetchedAt: time.Now(),
-		service:   "Sleep v2 - Getsummary", // todo use const
+		service:   subscription.NotificationDataServiceSleepv2Getsummary,
 	})
 
 	getParams := withings.NewSleepGetParams()
@@ -346,7 +354,7 @@ func (h fetchNotificationDataHandler) getAvailableData44(
 	ad = append(ad, availableData{
 		data:      sleepGetResponse.Raw,
 		fetchedAt: time.Now(),
-		service:   "Sleep v2 - Get",
+		service:   subscription.NotificationDataServiceSleepv2Get,
 	})
 
 	return ad, nil

--- a/pkg/withoutings/app/service/withings/withings_service.go
+++ b/pkg/withoutings/app/service/withings/withings_service.go
@@ -16,6 +16,9 @@ type Service interface {
 	SleepGetsummary(ctx context.Context, acc *account.Account, params withings.SleepGetsummaryParams) (*withings.SleepGetsummaryResponse, error)
 	SleepGet(ctx context.Context, acc *account.Account, params withings.SleepGetParams) (*withings.SleepGetResponse, error)
 	MeasureGetmeas(ctx context.Context, acc *account.Account, params withings.MeasureGetmeasParams) (*withings.MeasureGetmeasResponse, error)
+	MeasureGetactivity(ctx context.Context, acc *account.Account, params withings.MeasureGetactivityParams) (*withings.MeasureGetactivityResponse, error)
+	MeasureGetintradayactivity(ctx context.Context, acc *account.Account, params withings.MeasureGetintradayactivityParams) (*withings.MeasureGetintradayactivityResponse, error)
+	MeasureGetworkouts(ctx context.Context, acc *account.Account, params withings.MeasureGetworkoutsParams) (*withings.MeasureGetworkoutsResponse, error)
 }
 
 type service struct {
@@ -118,6 +121,18 @@ func (s *service) SleepGet(ctx context.Context, acc *account.Account, params wit
 
 func (s *service) MeasureGetmeas(ctx context.Context, acc *account.Account, params withings.MeasureGetmeasParams) (*withings.MeasureGetmeasResponse, error) {
 	return executeWithRetry(s, s.repo.MeasureGetmeas, ctx, acc, params)
+}
+
+func (s *service) MeasureGetactivity(ctx context.Context, acc *account.Account, params withings.MeasureGetactivityParams) (*withings.MeasureGetactivityResponse, error) {
+	return executeWithRetry(s, s.repo.MeasureGetactivity, ctx, acc, params)
+}
+
+func (s *service) MeasureGetintradayactivity(ctx context.Context, acc *account.Account, params withings.MeasureGetintradayactivityParams) (*withings.MeasureGetintradayactivityResponse, error) {
+	return executeWithRetry(s, s.repo.MeasureGetintradayactivity, ctx, acc, params)
+}
+
+func (s *service) MeasureGetworkouts(ctx context.Context, acc *account.Account, params withings.MeasureGetworkoutsParams) (*withings.MeasureGetworkoutsResponse, error) {
+	return executeWithRetry(s, s.repo.MeasureGetworkouts, ctx, acc, params)
 }
 
 func (s *service) CallService(ctx context.Context, acc *account.Account, appli int, params string) ([]byte, error) {

--- a/pkg/withoutings/app/service/withings/withings_service_mock.go
+++ b/pkg/withoutings/app/service/withings/withings_service_mock.go
@@ -39,6 +39,154 @@ func (_m *MockService) EXPECT() *MockService_Expecter {
 	return &MockService_Expecter{mock: &_m.Mock}
 }
 
+// MeasureGetactivity provides a mock function for the type MockService
+func (_mock *MockService) MeasureGetactivity(ctx context.Context, acc *account.Account, params withings.MeasureGetactivityParams) (*withings.MeasureGetactivityResponse, error) {
+	ret := _mock.Called(ctx, acc, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MeasureGetactivity")
+	}
+
+	var r0 *withings.MeasureGetactivityResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *account.Account, withings.MeasureGetactivityParams) (*withings.MeasureGetactivityResponse, error)); ok {
+		return returnFunc(ctx, acc, params)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *account.Account, withings.MeasureGetactivityParams) *withings.MeasureGetactivityResponse); ok {
+		r0 = returnFunc(ctx, acc, params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*withings.MeasureGetactivityResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *account.Account, withings.MeasureGetactivityParams) error); ok {
+		r1 = returnFunc(ctx, acc, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockService_MeasureGetactivity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MeasureGetactivity'
+type MockService_MeasureGetactivity_Call struct {
+	*mock.Call
+}
+
+// MeasureGetactivity is a helper method to define mock.On call
+//   - ctx context.Context
+//   - acc *account.Account
+//   - params withings.MeasureGetactivityParams
+func (_e *MockService_Expecter) MeasureGetactivity(ctx interface{}, acc interface{}, params interface{}) *MockService_MeasureGetactivity_Call {
+	return &MockService_MeasureGetactivity_Call{Call: _e.mock.On("MeasureGetactivity", ctx, acc, params)}
+}
+
+func (_c *MockService_MeasureGetactivity_Call) Run(run func(ctx context.Context, acc *account.Account, params withings.MeasureGetactivityParams)) *MockService_MeasureGetactivity_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *account.Account
+		if args[1] != nil {
+			arg1 = args[1].(*account.Account)
+		}
+		var arg2 withings.MeasureGetactivityParams
+		if args[2] != nil {
+			arg2 = args[2].(withings.MeasureGetactivityParams)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_MeasureGetactivity_Call) Return(measureGetactivityResponse *withings.MeasureGetactivityResponse, err error) *MockService_MeasureGetactivity_Call {
+	_c.Call.Return(measureGetactivityResponse, err)
+	return _c
+}
+
+func (_c *MockService_MeasureGetactivity_Call) RunAndReturn(run func(ctx context.Context, acc *account.Account, params withings.MeasureGetactivityParams) (*withings.MeasureGetactivityResponse, error)) *MockService_MeasureGetactivity_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MeasureGetintradayactivity provides a mock function for the type MockService
+func (_mock *MockService) MeasureGetintradayactivity(ctx context.Context, acc *account.Account, params withings.MeasureGetintradayactivityParams) (*withings.MeasureGetintradayactivityResponse, error) {
+	ret := _mock.Called(ctx, acc, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MeasureGetintradayactivity")
+	}
+
+	var r0 *withings.MeasureGetintradayactivityResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *account.Account, withings.MeasureGetintradayactivityParams) (*withings.MeasureGetintradayactivityResponse, error)); ok {
+		return returnFunc(ctx, acc, params)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *account.Account, withings.MeasureGetintradayactivityParams) *withings.MeasureGetintradayactivityResponse); ok {
+		r0 = returnFunc(ctx, acc, params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*withings.MeasureGetintradayactivityResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *account.Account, withings.MeasureGetintradayactivityParams) error); ok {
+		r1 = returnFunc(ctx, acc, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockService_MeasureGetintradayactivity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MeasureGetintradayactivity'
+type MockService_MeasureGetintradayactivity_Call struct {
+	*mock.Call
+}
+
+// MeasureGetintradayactivity is a helper method to define mock.On call
+//   - ctx context.Context
+//   - acc *account.Account
+//   - params withings.MeasureGetintradayactivityParams
+func (_e *MockService_Expecter) MeasureGetintradayactivity(ctx interface{}, acc interface{}, params interface{}) *MockService_MeasureGetintradayactivity_Call {
+	return &MockService_MeasureGetintradayactivity_Call{Call: _e.mock.On("MeasureGetintradayactivity", ctx, acc, params)}
+}
+
+func (_c *MockService_MeasureGetintradayactivity_Call) Run(run func(ctx context.Context, acc *account.Account, params withings.MeasureGetintradayactivityParams)) *MockService_MeasureGetintradayactivity_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *account.Account
+		if args[1] != nil {
+			arg1 = args[1].(*account.Account)
+		}
+		var arg2 withings.MeasureGetintradayactivityParams
+		if args[2] != nil {
+			arg2 = args[2].(withings.MeasureGetintradayactivityParams)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_MeasureGetintradayactivity_Call) Return(measureGetintradayactivityResponse *withings.MeasureGetintradayactivityResponse, err error) *MockService_MeasureGetintradayactivity_Call {
+	_c.Call.Return(measureGetintradayactivityResponse, err)
+	return _c
+}
+
+func (_c *MockService_MeasureGetintradayactivity_Call) RunAndReturn(run func(ctx context.Context, acc *account.Account, params withings.MeasureGetintradayactivityParams) (*withings.MeasureGetintradayactivityResponse, error)) *MockService_MeasureGetintradayactivity_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MeasureGetmeas provides a mock function for the type MockService
 func (_mock *MockService) MeasureGetmeas(ctx context.Context, acc *account.Account, params withings.MeasureGetmeasParams) (*withings.MeasureGetmeasResponse, error) {
 	ret := _mock.Called(ctx, acc, params)
@@ -109,6 +257,80 @@ func (_c *MockService_MeasureGetmeas_Call) Return(measureGetmeasResponse *within
 }
 
 func (_c *MockService_MeasureGetmeas_Call) RunAndReturn(run func(ctx context.Context, acc *account.Account, params withings.MeasureGetmeasParams) (*withings.MeasureGetmeasResponse, error)) *MockService_MeasureGetmeas_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MeasureGetworkouts provides a mock function for the type MockService
+func (_mock *MockService) MeasureGetworkouts(ctx context.Context, acc *account.Account, params withings.MeasureGetworkoutsParams) (*withings.MeasureGetworkoutsResponse, error) {
+	ret := _mock.Called(ctx, acc, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MeasureGetworkouts")
+	}
+
+	var r0 *withings.MeasureGetworkoutsResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *account.Account, withings.MeasureGetworkoutsParams) (*withings.MeasureGetworkoutsResponse, error)); ok {
+		return returnFunc(ctx, acc, params)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *account.Account, withings.MeasureGetworkoutsParams) *withings.MeasureGetworkoutsResponse); ok {
+		r0 = returnFunc(ctx, acc, params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*withings.MeasureGetworkoutsResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *account.Account, withings.MeasureGetworkoutsParams) error); ok {
+		r1 = returnFunc(ctx, acc, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockService_MeasureGetworkouts_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MeasureGetworkouts'
+type MockService_MeasureGetworkouts_Call struct {
+	*mock.Call
+}
+
+// MeasureGetworkouts is a helper method to define mock.On call
+//   - ctx context.Context
+//   - acc *account.Account
+//   - params withings.MeasureGetworkoutsParams
+func (_e *MockService_Expecter) MeasureGetworkouts(ctx interface{}, acc interface{}, params interface{}) *MockService_MeasureGetworkouts_Call {
+	return &MockService_MeasureGetworkouts_Call{Call: _e.mock.On("MeasureGetworkouts", ctx, acc, params)}
+}
+
+func (_c *MockService_MeasureGetworkouts_Call) Run(run func(ctx context.Context, acc *account.Account, params withings.MeasureGetworkoutsParams)) *MockService_MeasureGetworkouts_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *account.Account
+		if args[1] != nil {
+			arg1 = args[1].(*account.Account)
+		}
+		var arg2 withings.MeasureGetworkoutsParams
+		if args[2] != nil {
+			arg2 = args[2].(withings.MeasureGetworkoutsParams)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_MeasureGetworkouts_Call) Return(measureGetworkoutsResponse *withings.MeasureGetworkoutsResponse, err error) *MockService_MeasureGetworkouts_Call {
+	_c.Call.Return(measureGetworkoutsResponse, err)
+	return _c
+}
+
+func (_c *MockService_MeasureGetworkouts_Call) RunAndReturn(run func(ctx context.Context, acc *account.Account, params withings.MeasureGetworkoutsParams) (*withings.MeasureGetworkoutsResponse, error)) *MockService_MeasureGetworkouts_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/withoutings/domain/subscription/notification_data_service.go
+++ b/pkg/withoutings/domain/subscription/notification_data_service.go
@@ -10,6 +10,7 @@ type NotificationDataService string
 const NotificationDataServiceMeasureGetMeas NotificationDataService = "Measure - Getmeas"
 const NotificationDataServiceMeasurev2Getactivity NotificationDataService = "Measure v2 - Getactivity"
 const NotificationDataServiceMeasurev2Getintradayactivity NotificationDataService = "Measure v2 - Getintradayactivity"
+const NotificationDataServiceMeasurev2Getworkouts NotificationDataService = "Measure v2 - Getworkouts"
 const NotificationDataServiceSleepv2Get NotificationDataService = "Sleep v2 - Get"
 const NotificationDataServiceSleepv2Getsummary NotificationDataService = "Sleep v2 - Getsummary"
 const NotificationDataServiceHeartv2List NotificationDataService = "Heart v2 - List"
@@ -22,6 +23,8 @@ func NewNotificationDataService(s string) (NotificationDataService, error) {
 		return NotificationDataServiceMeasurev2Getactivity, nil
 	case "Measure v2 - Getintradayactivity":
 		return NotificationDataServiceMeasurev2Getintradayactivity, nil
+	case "Measure v2 - Getworkouts":
+		return NotificationDataServiceMeasurev2Getworkouts, nil
 	case "Sleep v2 - Get":
 		return NotificationDataServiceSleepv2Get, nil
 	case "Sleep v2 - Getsummary":

--- a/pkg/withoutings/domain/withings/domain_withingsrepo.go
+++ b/pkg/withoutings/domain/withings/domain_withingsrepo.go
@@ -15,4 +15,7 @@ type Repo interface {
 	SleepGetsummary(ctx context.Context, accessToken string, params SleepGetsummaryParams) (*SleepGetsummaryResponse, error)
 	SleepGet(ctx context.Context, accessToken string, params SleepGetParams) (*SleepGetResponse, error)
 	MeasureGetmeas(ctx context.Context, accessToken string, params MeasureGetmeasParams) (*MeasureGetmeasResponse, error)
+	MeasureGetactivity(ctx context.Context, accessToken string, params MeasureGetactivityParams) (*MeasureGetactivityResponse, error)
+	MeasureGetintradayactivity(ctx context.Context, accessToken string, params MeasureGetintradayactivityParams) (*MeasureGetintradayactivityResponse, error)
+	MeasureGetworkouts(ctx context.Context, accessToken string, params MeasureGetworkoutsParams) (*MeasureGetworkoutsResponse, error)
 }

--- a/pkg/withoutings/domain/withings/domain_withingsrepo_mock.go
+++ b/pkg/withoutings/domain/withings/domain_withingsrepo_mock.go
@@ -156,6 +156,154 @@ func (_c *MockRepo_GetAccessToken_Call) RunAndReturn(run func(ctx context.Contex
 	return _c
 }
 
+// MeasureGetactivity provides a mock function for the type MockRepo
+func (_mock *MockRepo) MeasureGetactivity(ctx context.Context, accessToken string, params MeasureGetactivityParams) (*MeasureGetactivityResponse, error) {
+	ret := _mock.Called(ctx, accessToken, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MeasureGetactivity")
+	}
+
+	var r0 *MeasureGetactivityResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, MeasureGetactivityParams) (*MeasureGetactivityResponse, error)); ok {
+		return returnFunc(ctx, accessToken, params)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, MeasureGetactivityParams) *MeasureGetactivityResponse); ok {
+		r0 = returnFunc(ctx, accessToken, params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*MeasureGetactivityResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, MeasureGetactivityParams) error); ok {
+		r1 = returnFunc(ctx, accessToken, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepo_MeasureGetactivity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MeasureGetactivity'
+type MockRepo_MeasureGetactivity_Call struct {
+	*mock.Call
+}
+
+// MeasureGetactivity is a helper method to define mock.On call
+//   - ctx context.Context
+//   - accessToken string
+//   - params MeasureGetactivityParams
+func (_e *MockRepo_Expecter) MeasureGetactivity(ctx interface{}, accessToken interface{}, params interface{}) *MockRepo_MeasureGetactivity_Call {
+	return &MockRepo_MeasureGetactivity_Call{Call: _e.mock.On("MeasureGetactivity", ctx, accessToken, params)}
+}
+
+func (_c *MockRepo_MeasureGetactivity_Call) Run(run func(ctx context.Context, accessToken string, params MeasureGetactivityParams)) *MockRepo_MeasureGetactivity_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 MeasureGetactivityParams
+		if args[2] != nil {
+			arg2 = args[2].(MeasureGetactivityParams)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepo_MeasureGetactivity_Call) Return(measureGetactivityResponse *MeasureGetactivityResponse, err error) *MockRepo_MeasureGetactivity_Call {
+	_c.Call.Return(measureGetactivityResponse, err)
+	return _c
+}
+
+func (_c *MockRepo_MeasureGetactivity_Call) RunAndReturn(run func(ctx context.Context, accessToken string, params MeasureGetactivityParams) (*MeasureGetactivityResponse, error)) *MockRepo_MeasureGetactivity_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MeasureGetintradayactivity provides a mock function for the type MockRepo
+func (_mock *MockRepo) MeasureGetintradayactivity(ctx context.Context, accessToken string, params MeasureGetintradayactivityParams) (*MeasureGetintradayactivityResponse, error) {
+	ret := _mock.Called(ctx, accessToken, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MeasureGetintradayactivity")
+	}
+
+	var r0 *MeasureGetintradayactivityResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, MeasureGetintradayactivityParams) (*MeasureGetintradayactivityResponse, error)); ok {
+		return returnFunc(ctx, accessToken, params)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, MeasureGetintradayactivityParams) *MeasureGetintradayactivityResponse); ok {
+		r0 = returnFunc(ctx, accessToken, params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*MeasureGetintradayactivityResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, MeasureGetintradayactivityParams) error); ok {
+		r1 = returnFunc(ctx, accessToken, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepo_MeasureGetintradayactivity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MeasureGetintradayactivity'
+type MockRepo_MeasureGetintradayactivity_Call struct {
+	*mock.Call
+}
+
+// MeasureGetintradayactivity is a helper method to define mock.On call
+//   - ctx context.Context
+//   - accessToken string
+//   - params MeasureGetintradayactivityParams
+func (_e *MockRepo_Expecter) MeasureGetintradayactivity(ctx interface{}, accessToken interface{}, params interface{}) *MockRepo_MeasureGetintradayactivity_Call {
+	return &MockRepo_MeasureGetintradayactivity_Call{Call: _e.mock.On("MeasureGetintradayactivity", ctx, accessToken, params)}
+}
+
+func (_c *MockRepo_MeasureGetintradayactivity_Call) Run(run func(ctx context.Context, accessToken string, params MeasureGetintradayactivityParams)) *MockRepo_MeasureGetintradayactivity_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 MeasureGetintradayactivityParams
+		if args[2] != nil {
+			arg2 = args[2].(MeasureGetintradayactivityParams)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepo_MeasureGetintradayactivity_Call) Return(measureGetintradayactivityResponse *MeasureGetintradayactivityResponse, err error) *MockRepo_MeasureGetintradayactivity_Call {
+	_c.Call.Return(measureGetintradayactivityResponse, err)
+	return _c
+}
+
+func (_c *MockRepo_MeasureGetintradayactivity_Call) RunAndReturn(run func(ctx context.Context, accessToken string, params MeasureGetintradayactivityParams) (*MeasureGetintradayactivityResponse, error)) *MockRepo_MeasureGetintradayactivity_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MeasureGetmeas provides a mock function for the type MockRepo
 func (_mock *MockRepo) MeasureGetmeas(ctx context.Context, accessToken string, params MeasureGetmeasParams) (*MeasureGetmeasResponse, error) {
 	ret := _mock.Called(ctx, accessToken, params)
@@ -226,6 +374,80 @@ func (_c *MockRepo_MeasureGetmeas_Call) Return(measureGetmeasResponse *MeasureGe
 }
 
 func (_c *MockRepo_MeasureGetmeas_Call) RunAndReturn(run func(ctx context.Context, accessToken string, params MeasureGetmeasParams) (*MeasureGetmeasResponse, error)) *MockRepo_MeasureGetmeas_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MeasureGetworkouts provides a mock function for the type MockRepo
+func (_mock *MockRepo) MeasureGetworkouts(ctx context.Context, accessToken string, params MeasureGetworkoutsParams) (*MeasureGetworkoutsResponse, error) {
+	ret := _mock.Called(ctx, accessToken, params)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MeasureGetworkouts")
+	}
+
+	var r0 *MeasureGetworkoutsResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, MeasureGetworkoutsParams) (*MeasureGetworkoutsResponse, error)); ok {
+		return returnFunc(ctx, accessToken, params)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, MeasureGetworkoutsParams) *MeasureGetworkoutsResponse); ok {
+		r0 = returnFunc(ctx, accessToken, params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*MeasureGetworkoutsResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, MeasureGetworkoutsParams) error); ok {
+		r1 = returnFunc(ctx, accessToken, params)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepo_MeasureGetworkouts_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MeasureGetworkouts'
+type MockRepo_MeasureGetworkouts_Call struct {
+	*mock.Call
+}
+
+// MeasureGetworkouts is a helper method to define mock.On call
+//   - ctx context.Context
+//   - accessToken string
+//   - params MeasureGetworkoutsParams
+func (_e *MockRepo_Expecter) MeasureGetworkouts(ctx interface{}, accessToken interface{}, params interface{}) *MockRepo_MeasureGetworkouts_Call {
+	return &MockRepo_MeasureGetworkouts_Call{Call: _e.mock.On("MeasureGetworkouts", ctx, accessToken, params)}
+}
+
+func (_c *MockRepo_MeasureGetworkouts_Call) Run(run func(ctx context.Context, accessToken string, params MeasureGetworkoutsParams)) *MockRepo_MeasureGetworkouts_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 MeasureGetworkoutsParams
+		if args[2] != nil {
+			arg2 = args[2].(MeasureGetworkoutsParams)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepo_MeasureGetworkouts_Call) Return(measureGetworkoutsResponse *MeasureGetworkoutsResponse, err error) *MockRepo_MeasureGetworkouts_Call {
+	_c.Call.Return(measureGetworkoutsResponse, err)
+	return _c
+}
+
+func (_c *MockRepo_MeasureGetworkouts_Call) RunAndReturn(run func(ctx context.Context, accessToken string, params MeasureGetworkoutsParams) (*MeasureGetworkoutsResponse, error)) *MockRepo_MeasureGetworkouts_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/withoutings/domain/withings/http_measure_v2_getactivity.go
+++ b/pkg/withoutings/domain/withings/http_measure_v2_getactivity.go
@@ -1,0 +1,71 @@
+package withings
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// https://developer.withings.com/api-reference#operation/measurev2-getactivity
+
+var MeasureGetactivityAllDataFields = strings.Join([]string{
+	"steps",
+	"distance",
+	"elevation",
+	"soft",
+	"moderate",
+	"intense",
+	"active",
+	"calories",
+	"totalcalories",
+	"hr_average",
+	"hr_min",
+	"hr_max",
+	"hr_zone_0",
+	"hr_zone_1",
+	"hr_zone_2",
+	"hr_zone_3",
+}, ",")
+
+// NewMeasureGetactivityParams creates new MeasureGetactivityParams with some defaults.
+func NewMeasureGetactivityParams() MeasureGetactivityParams {
+	return MeasureGetactivityParams{
+		Action:     "getactivity",
+		DataFields: MeasureGetactivityAllDataFields,
+	}
+}
+
+// MeasureGetactivityParams
+// Don't set Lastupdate and Startdateymd or Enddateymd at the same time.
+type MeasureGetactivityParams struct {
+	Action       string `json:"action" url:"action"`
+	Startdateymd string `json:"startdateymd,omitempty" url:"startdateymd,omitempty"`
+	Enddateymd   string `json:"enddateymd,omitempty" url:"enddateymd,omitempty"`
+	Lastupdate   int64  `json:"lastupdate,omitempty" url:"lastupdate,omitempty"`
+	Offset       int    `json:"offset,omitempty" url:"offset,omitempty"`
+	DataFields   string `json:"data_fields" url:"data_fields"`
+}
+
+type MeasureGetactivityResponse struct {
+	Status int                    `json:"status"`
+	Body   MeasureGetactivityBody `json:"body"`
+	Raw    []byte                 `json:"-"`
+}
+
+func MustNewMeasureGetactivityResponse(raw []byte) *MeasureGetactivityResponse {
+	var resp MeasureGetactivityResponse
+	err := json.Unmarshal(raw, &resp)
+	resp.Raw = raw
+
+	if err != nil {
+		panic(fmt.Errorf(`couldn't unmarshal MeasureGetactivityResponse: %w`, err))
+	}
+
+	return &resp
+}
+
+type MeasureGetactivityBody struct {
+	Activities []json.RawMessage `json:"activities"`
+	More       bool              `json:"more"`
+	Offset     int               `json:"offset"`
+}

--- a/pkg/withoutings/domain/withings/http_measure_v2_getintradayactivity.go
+++ b/pkg/withoutings/domain/withings/http_measure_v2_getintradayactivity.go
@@ -1,0 +1,68 @@
+package withings
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// https://developer.withings.com/api-reference#operation/measurev2-getintradayactivity
+
+var MeasureGetintradayactivityAllDataFields = strings.Join([]string{
+	"steps",
+	"elevation",
+	"calories",
+	"distance",
+	"stroke",
+	"pool_lap",
+	"duration",
+	"heart_rate",
+	"spo2_auto",
+	"rmssd",
+	"sdnn1",
+	"hrv_quality",
+	"core_body_temperature",
+	"rr",
+	"chest_movement_rate",
+}, ",")
+
+// NewMeasureGetintradayactivityParams creates new MeasureGetintradayactivityParams with some defaults.
+func NewMeasureGetintradayactivityParams() MeasureGetintradayactivityParams {
+	return MeasureGetintradayactivityParams{
+		Action:     "getintradayactivity",
+		DataFields: MeasureGetintradayactivityAllDataFields,
+	}
+}
+
+// MeasureGetintradayactivityParams are the parameters for Measure v2 - Getintradayactivity.
+type MeasureGetintradayactivityParams struct {
+	Action     string `json:"action" url:"action"`
+	Startdate  int64  `json:"startdate,omitempty" url:"startdate,omitempty"`
+	Enddate    int64  `json:"enddate,omitempty" url:"enddate,omitempty"`
+	DataFields string `json:"data_fields" url:"data_fields"`
+}
+
+type MeasureGetintradayactivityResponse struct {
+	Status int                              `json:"status"`
+	Body   MeasureGetintradayactivityBody   `json:"body"`
+	Raw    []byte                           `json:"-"`
+}
+
+func MustNewMeasureGetintradayactivityResponse(raw []byte) *MeasureGetintradayactivityResponse {
+	var resp MeasureGetintradayactivityResponse
+	err := json.Unmarshal(raw, &resp)
+	resp.Raw = raw
+
+	if err != nil {
+		panic(fmt.Errorf(`couldn't unmarshal MeasureGetintradayactivityResponse: %w`, err))
+	}
+
+	return &resp
+}
+
+// MeasureGetintradayactivityBody preserves the raw "series" object — the API returns
+// an object keyed by unix timestamp (or sometimes {} when there is no data),
+// not an array.
+type MeasureGetintradayactivityBody struct {
+	Series json.RawMessage `json:"series"`
+}

--- a/pkg/withoutings/domain/withings/http_measure_v2_getworkouts.go
+++ b/pkg/withoutings/domain/withings/http_measure_v2_getworkouts.go
@@ -1,0 +1,80 @@
+package withings
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// https://developer.withings.com/api-reference#operation/measurev2-getworkouts
+
+var MeasureGetworkoutsAllDataFields = strings.Join([]string{
+	"calories",
+	"intensity",
+	"manual_intensity",
+	"manual_distance",
+	"manual_calories",
+	"hr_average",
+	"hr_min",
+	"hr_max",
+	"hr_zone_0",
+	"hr_zone_1",
+	"hr_zone_2",
+	"hr_zone_3",
+	"pause_duration",
+	"algo_pause_duration",
+	"spo2_average",
+	"core_body_temperature_avg",
+	"core_body_temperature_min",
+	"core_body_temperature_max",
+	"core_body_temperature_status",
+	"steps",
+	"distance",
+	"elevation",
+	"pool_laps",
+	"strokes",
+	"pool_length",
+}, ",")
+
+// NewMeasureGetworkoutsParams creates new MeasureGetworkoutsParams with some defaults.
+func NewMeasureGetworkoutsParams() MeasureGetworkoutsParams {
+	return MeasureGetworkoutsParams{
+		Action:     "getworkouts",
+		DataFields: MeasureGetworkoutsAllDataFields,
+	}
+}
+
+// MeasureGetworkoutsParams
+// Don't set Lastupdate and Startdateymd or Enddateymd at the same time.
+type MeasureGetworkoutsParams struct {
+	Action       string `json:"action" url:"action"`
+	Startdateymd string `json:"startdateymd,omitempty" url:"startdateymd,omitempty"`
+	Enddateymd   string `json:"enddateymd,omitempty" url:"enddateymd,omitempty"`
+	Lastupdate   int64  `json:"lastupdate,omitempty" url:"lastupdate,omitempty"`
+	Offset       int    `json:"offset,omitempty" url:"offset,omitempty"`
+	DataFields   string `json:"data_fields" url:"data_fields"`
+}
+
+type MeasureGetworkoutsResponse struct {
+	Status int                    `json:"status"`
+	Body   MeasureGetworkoutsBody `json:"body"`
+	Raw    []byte                 `json:"-"`
+}
+
+func MustNewMeasureGetworkoutsResponse(raw []byte) *MeasureGetworkoutsResponse {
+	var resp MeasureGetworkoutsResponse
+	err := json.Unmarshal(raw, &resp)
+	resp.Raw = raw
+
+	if err != nil {
+		panic(fmt.Errorf(`couldn't unmarshal MeasureGetworkoutsResponse: %w`, err))
+	}
+
+	return &resp
+}
+
+type MeasureGetworkoutsBody struct {
+	Series []json.RawMessage `json:"series"`
+	More   bool              `json:"more"`
+	Offset int               `json:"offset"`
+}

--- a/pkg/withoutings/port/subscriptions_notifications_test.go
+++ b/pkg/withoutings/port/subscriptions_notifications_test.go
@@ -65,6 +65,45 @@ func TestNotificationsPage(t *testing.T) {
 		}, 10*time.Second, 300*time.Millisecond, "should show received notifications with links to fetched payloads")
 	})
 
+	t.Run("should fetch new activity data when receiving appli=16 webhook", func(t *testing.T) {
+		// appli=16 (New activity-related data) has three services to call:
+		// - Measure v2 - Getactivity
+		// - Measure v2 - Getintradayactivity
+		// - Measure v2 - Getworkouts
+		// The webhook payload uses date=YYYY-MM-DD (not startdate/enddate).
+
+		beforeEach(t)
+
+		workerCtx, cancelWorker := context.WithCancel(it.Ctx)
+		defer cancelWorker()
+
+		it.Mocks.MockWithingsSvc.EXPECT().
+			MeasureGetactivity(mock.Anything, mock.Anything, mock.Anything).
+			Return(withings.MustNewMeasureGetactivityResponse(withingstestdata.MeasureGetactivitySuccess), nil)
+		it.Mocks.MockWithingsSvc.EXPECT().
+			MeasureGetintradayactivity(mock.Anything, mock.Anything, mock.Anything).
+			Return(withings.MustNewMeasureGetintradayactivityResponse(withingstestdata.MeasureGetintradayactivitySuccess), nil)
+		it.Mocks.MockWithingsSvc.EXPECT().
+			MeasureGetworkouts(mock.Anything, mock.Anything, mock.Anything).
+			Return(withings.MustNewMeasureGetworkoutsResponse(withingstestdata.MeasureGetworkoutsSuccess), nil)
+
+		defer it.Mocks.MockWithingsSvc.AssertExpectations(t)
+
+		go it.Worker.Work(workerCtx)
+
+		activity16WebhookParams := fmt.Sprintf(`userid=%s&appli=16&date=2022-01-26`, acc.WithingsUserID())
+		simulateIncomingWebhook(activity16WebhookParams)
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			resp, body := it.DoRequest(newListNotificationsReq())
+			assert.Equal(c, 200, resp.Code)
+
+			assert.Contains(c, body, "Measure v2 - Getactivity<")
+			assert.Contains(c, body, "Measure v2 - Getintradayactivity<")
+			assert.Contains(c, body, "Measure v2 - Getworkouts<")
+		}, 10*time.Second, 300*time.Millisecond, "should show received activity notification with three fetched payloads")
+	})
+
 	t.Run("should fetch new available data from multiple services", func(t *testing.T) {
 		// Some notification categories have multiple services to call,
 		// in order to retrieve all the relevant data.

--- a/pkg/withoutings/port/subscriptions_notifications_test.go
+++ b/pkg/withoutings/port/subscriptions_notifications_test.go
@@ -78,15 +78,17 @@ func TestNotificationsPage(t *testing.T) {
 		defer cancelWorker()
 
 		// Pin params so a regression in the YMD-vs-Unix split is caught.
-		// Daily endpoints use the date directly; intraday uses a widened
-		// [day-24h, day+48h] UTC window so any user timezone is covered.
+		// Daily endpoints use the date directly. Intraday uses a precise
+		// local-day window derived from the timezone field on the first
+		// activity row in the Getactivity response (Europe/Oslo, +01:00 in
+		// January) — see the success fixture.
 		getactivityParams := withings.NewMeasureGetactivityParams()
 		getactivityParams.Startdateymd = "2022-01-26"
 		getactivityParams.Enddateymd = "2022-01-26"
 
 		intradayParams := withings.NewMeasureGetintradayactivityParams()
-		intradayParams.Startdate = 1643068800 // 2022-01-25 00:00 UTC
-		intradayParams.Enddate = 1643328000   // 2022-01-28 00:00 UTC
+		intradayParams.Startdate = 1643151600 // 2022-01-26 00:00 Europe/Oslo
+		intradayParams.Enddate = 1643238000   // 2022-01-27 00:00 Europe/Oslo
 
 		getworkoutsParams := withings.NewMeasureGetworkoutsParams()
 		getworkoutsParams.Startdateymd = "2022-01-26"
@@ -125,11 +127,17 @@ func TestNotificationsPage(t *testing.T) {
 		workerCtx, cancelWorker := context.WithCancel(it.Ctx)
 		defer cancelWorker()
 
+		// With no activity rows we can't read a timezone, so the intraday
+		// window falls back to UTC midnight-to-midnight.
+		intradayParams := withings.NewMeasureGetintradayactivityParams()
+		intradayParams.Startdate = 1643155200 // 2022-01-26 00:00 UTC
+		intradayParams.Enddate = 1643241600   // 2022-01-27 00:00 UTC
+
 		it.Mocks.MockWithingsSvc.EXPECT().
 			MeasureGetactivity(mock.Anything, mock.Anything, mock.Anything).
 			Return(withings.MustNewMeasureGetactivityResponse(withingstestdata.MeasureGetactivityNoData), nil)
 		it.Mocks.MockWithingsSvc.EXPECT().
-			MeasureGetintradayactivity(mock.Anything, mock.Anything, mock.Anything).
+			MeasureGetintradayactivity(mock.Anything, mock.Anything, intradayParams).
 			Return(withings.MustNewMeasureGetintradayactivityResponse(withingstestdata.MeasureGetintradayactivityNoData), nil)
 		it.Mocks.MockWithingsSvc.EXPECT().
 			MeasureGetworkouts(mock.Anything, mock.Anything, mock.Anything).

--- a/pkg/withoutings/port/subscriptions_notifications_test.go
+++ b/pkg/withoutings/port/subscriptions_notifications_test.go
@@ -77,14 +77,29 @@ func TestNotificationsPage(t *testing.T) {
 		workerCtx, cancelWorker := context.WithCancel(it.Ctx)
 		defer cancelWorker()
 
+		// Pin params so a regression in the YMD-vs-Unix split is caught.
+		// Daily endpoints use the date directly; intraday uses a widened
+		// [day-24h, day+48h] UTC window so any user timezone is covered.
+		getactivityParams := withings.NewMeasureGetactivityParams()
+		getactivityParams.Startdateymd = "2022-01-26"
+		getactivityParams.Enddateymd = "2022-01-26"
+
+		intradayParams := withings.NewMeasureGetintradayactivityParams()
+		intradayParams.Startdate = 1643068800 // 2022-01-25 00:00 UTC
+		intradayParams.Enddate = 1643328000   // 2022-01-28 00:00 UTC
+
+		getworkoutsParams := withings.NewMeasureGetworkoutsParams()
+		getworkoutsParams.Startdateymd = "2022-01-26"
+		getworkoutsParams.Enddateymd = "2022-01-26"
+
 		it.Mocks.MockWithingsSvc.EXPECT().
-			MeasureGetactivity(mock.Anything, mock.Anything, mock.Anything).
+			MeasureGetactivity(mock.Anything, mock.Anything, getactivityParams).
 			Return(withings.MustNewMeasureGetactivityResponse(withingstestdata.MeasureGetactivitySuccess), nil)
 		it.Mocks.MockWithingsSvc.EXPECT().
-			MeasureGetintradayactivity(mock.Anything, mock.Anything, mock.Anything).
+			MeasureGetintradayactivity(mock.Anything, mock.Anything, intradayParams).
 			Return(withings.MustNewMeasureGetintradayactivityResponse(withingstestdata.MeasureGetintradayactivitySuccess), nil)
 		it.Mocks.MockWithingsSvc.EXPECT().
-			MeasureGetworkouts(mock.Anything, mock.Anything, mock.Anything).
+			MeasureGetworkouts(mock.Anything, mock.Anything, getworkoutsParams).
 			Return(withings.MustNewMeasureGetworkoutsResponse(withingstestdata.MeasureGetworkoutsSuccess), nil)
 
 		defer it.Mocks.MockWithingsSvc.AssertExpectations(t)
@@ -102,6 +117,63 @@ func TestNotificationsPage(t *testing.T) {
 			assert.Contains(c, body, "Measure v2 - Getintradayactivity<")
 			assert.Contains(c, body, "Measure v2 - Getworkouts<")
 		}, 10*time.Second, 300*time.Millisecond, "should show received activity notification with three fetched payloads")
+	})
+
+	t.Run("should still record appli=16 notification when Withings returns no data", func(t *testing.T) {
+		beforeEach(t)
+
+		workerCtx, cancelWorker := context.WithCancel(it.Ctx)
+		defer cancelWorker()
+
+		it.Mocks.MockWithingsSvc.EXPECT().
+			MeasureGetactivity(mock.Anything, mock.Anything, mock.Anything).
+			Return(withings.MustNewMeasureGetactivityResponse(withingstestdata.MeasureGetactivityNoData), nil)
+		it.Mocks.MockWithingsSvc.EXPECT().
+			MeasureGetintradayactivity(mock.Anything, mock.Anything, mock.Anything).
+			Return(withings.MustNewMeasureGetintradayactivityResponse(withingstestdata.MeasureGetintradayactivityNoData), nil)
+		it.Mocks.MockWithingsSvc.EXPECT().
+			MeasureGetworkouts(mock.Anything, mock.Anything, mock.Anything).
+			Return(withings.MustNewMeasureGetworkoutsResponse(withingstestdata.MeasureGetworkoutsNoData), nil)
+
+		defer it.Mocks.MockWithingsSvc.AssertExpectations(t)
+
+		go it.Worker.Work(workerCtx)
+
+		simulateIncomingWebhook(fmt.Sprintf(`userid=%s&appli=16&date=2022-01-26`, acc.WithingsUserID()))
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			resp, body := it.DoRequest(newListNotificationsReq())
+			assert.Equal(c, 200, resp.Code)
+
+			assert.Contains(c, body, "Measure v2 - Getactivity<")
+			assert.Contains(c, body, "Measure v2 - Getintradayactivity<")
+			assert.Contains(c, body, "Measure v2 - Getworkouts<")
+		}, 10*time.Second, 300*time.Millisecond, "empty payloads should still produce three NotificationData rows")
+	})
+
+	t.Run("should not loop forever when appli=16 webhook has malformed date", func(t *testing.T) {
+		// A malformed date= must not propagate as an error to watermill,
+		// or the message will redeliver indefinitely.
+		beforeEach(t)
+
+		workerCtx, cancelWorker := context.WithCancel(it.Ctx)
+		defer cancelWorker()
+
+		// No EXPECT(): any Withings call would be a regression. AssertExpectations
+		// also fails the test if any unexpected call is made.
+		defer it.Mocks.MockWithingsSvc.AssertExpectations(t)
+
+		go it.Worker.Work(workerCtx)
+
+		simulateIncomingWebhook(fmt.Sprintf(`userid=%s&appli=16&date=not-a-date`, acc.WithingsUserID()))
+
+		// The notification should be processed (handler returns nil) so the
+		// page renders, and no Withings service rows show up for it.
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			resp, body := it.DoRequest(newListNotificationsReq())
+			assert.Equal(c, 200, resp.Code)
+			assert.NotContains(c, body, "Measure v2 - ")
+		}, 10*time.Second, 300*time.Millisecond, "malformed date should be handled without retries or service rows")
 	})
 
 	t.Run("should fetch new available data from multiple services", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fetch and persist Measure v2 - Getactivity, Getintradayactivity, and Getworkouts when an `appli=16` webhook arrives, instead of failing with `not yet able to handle appli: 16`.
- Webhook payload uses `date=YYYY-MM-DD` (unlike sleep, which uses unix `startdate`/`enddate`); the dispatcher parses the date and uses it for both daily endpoints, plus a 24h UTC window for intraday.
- Adds `Measure v2 - Getworkouts` to the `NotificationDataService` allowlist so the notifications page can render the stored payload.

## Test plan

- [x] `go test ./...` green
- [x] New integration subtest `TestNotificationsPage/should_fetch_new_activity_data_when_receiving_appli=16_webhook` exercises the full webhook → process → fetch path with all three Measure v2 calls mocked.
- [ ] Re-run any stuck `data_status=awaiting_fetch` notifications in production after deploy.