### PR TITLE
handle appli=46 (user.info) webhooks

### DIFF
--- a/pkg/withoutings/app/command/fetch_notification_data.go
+++ b/pkg/withoutings/app/command/fetch_notification_data.go
@@ -152,6 +152,8 @@ func (h fetchNotificationDataHandler) getAvailableData(ctx context.Context, acc 
 		return h.getAvailableData16(ctx, acc, parsedParams)
 	case 44:
 		return h.getAvailableData44(ctx, acc, parsedParams)
+	case 46:
+		return h.getAvailableData46(ctx, acc, parsedParams)
 	case 50:
 		return h.getAvailableData50(ctx, acc, parsedParams)
 	case 51:
@@ -385,6 +387,22 @@ func (h fetchNotificationDataHandler) getAvailableData44(
 	})
 
 	return ad, nil
+}
+
+// getAvailableData46 fetches data from Withings API for appli 46:
+// New action on user profile (delete / unlink / update).
+// The webhook carries `action=...`, but Withings exposes no service to fetch
+// further data for it.
+func (h fetchNotificationDataHandler) getAvailableData46(
+	_ context.Context,
+	_ *account.Account,
+	parsedParams subscription.ParsedNotificationParams,
+) (availableDatas, error) {
+	if parsedParams.Appli != 46 {
+		panic("getAvailableData46 called with wrong application ID")
+	}
+	// No service to call
+	return availableDatas{}, nil
 }
 
 // getAvailableData50 fetches data from Withings API for appli 50:

--- a/pkg/withoutings/port/subscriptions_notifications_test.go
+++ b/pkg/withoutings/port/subscriptions_notifications_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/roessland/withoutings/pkg/integrationtest"
 	"github.com/roessland/withoutings/pkg/withoutings/adapter/withings/withingstestdata"
 	"github.com/roessland/withoutings/pkg/withoutings/domain/account"
+	"github.com/roessland/withoutings/pkg/withoutings/domain/subscription"
 	"github.com/roessland/withoutings/pkg/withoutings/domain/withings"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -182,6 +183,35 @@ func TestNotificationsPage(t *testing.T) {
 			assert.Equal(c, 200, resp.Code)
 			assert.NotContains(c, body, "Measure v2 - ")
 		}, 10*time.Second, 300*time.Millisecond, "malformed date should be handled without retries or service rows")
+	})
+
+	t.Run("should record appli=46 user.info notification without calling any service", func(t *testing.T) {
+		// appli=46 (user.info: delete/unlink/update) has no service to call.
+		// The handler must mark the notification as fetched without invoking
+		// any Withings API, otherwise watermill will redeliver indefinitely.
+		beforeEach(t)
+
+		workerCtx, cancelWorker := context.WithCancel(it.Ctx)
+		defer cancelWorker()
+
+		// No EXPECT(): any Withings call would be a regression. AssertExpectations
+		// also fails the test if any unexpected call is made.
+		defer it.Mocks.MockWithingsSvc.AssertExpectations(t)
+
+		go it.Worker.Work(workerCtx)
+
+		simulateIncomingWebhook(fmt.Sprintf(`userid=%s&appli=46&action=update`, acc.WithingsUserID()))
+
+		// Assert the notification reaches `fetched` rather than just looking at
+		// the rendered page — the page renders awaiting/fetched the same way,
+		// so a status check is the only way to catch the redelivery loop.
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			notifications, err := it.App.SubscriptionRepo.GetNotificationsByAccountUUID(it.Ctx, acc.UUID())
+			if !assert.NoError(c, err) || !assert.Len(c, notifications, 1) {
+				return
+			}
+			assert.Equal(c, subscription.NotificationDataStatusFetched, notifications[0].DataStatus())
+		}, 10*time.Second, 300*time.Millisecond, "appli=46 should be marked fetched without any service call")
 	})
 
 	t.Run("should fetch new available data from multiple services", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add a `case 46` to `fetchNotificationDataHandler.getAvailableData` so `appli=46` (user.info: delete/unlink/update) is acknowledged instead of returning `not yet able to handle appli: 46` and looping in watermill forever.
- Withings exposes no service to fetch for this category, so the new `getAvailableData46` returns an empty `availableDatas` (mirrors the existing `appli=50`/`appli=51` pattern).
- Add a port-level test that asserts the notification reaches `NotificationDataStatusFetched` without any `MockWithingsSvc` calls — the rendered page can't distinguish awaiting/fetched, so a status check is the only way to catch the redelivery loop.

## Test plan
- [x] `PGPORT=54329 go test ./pkg/withoutings/port/ -run 'TestNotificationsPage' -count=1`
- [x] `PGPORT=54329 go test ./... -count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)