### PR TITLE
sleep session detail page

### DIFF
--- a/pkg/db/subscription.sql
+++ b/pkg/db/subscription.sql
@@ -150,3 +150,17 @@ FROM notification_data
 WHERE account_uuid = $1
   AND service = $2
 ORDER BY fetched_at DESC;
+
+-- name: GetNotificationDataByAccountAndServiceAndSeriesStartdate :many
+-- Returns notification_data rows whose JSONB body.series array contains an
+-- entry with the requested startdate. Used by the sleep detail page so the
+-- Getsummary-by-startdate lookup is a single indexed query rather than
+-- "fetch every summary and filter in Go". Backed by the GIN index
+-- notification_data_body_series_idx.
+SELECT *
+FROM notification_data
+WHERE account_uuid = $1
+  AND service = $2
+  AND data -> 'body' -> 'series' @> jsonb_build_array(jsonb_build_object('startdate', sqlc.arg(startdate)::bigint))
+ORDER BY fetched_at DESC
+LIMIT 1;

--- a/pkg/db/subscription.sql
+++ b/pkg/db/subscription.sql
@@ -143,3 +143,10 @@ ON CONFLICT (notification_uuid, service) DO NOTHING;
 SELECT *
 FROM notification_data
 WHERE notification_uuid = $1;
+
+-- name: GetNotificationDataByAccountUUIDAndService :many
+SELECT *
+FROM notification_data
+WHERE account_uuid = $1
+  AND service = $2
+ORDER BY fetched_at DESC;

--- a/pkg/db/subscription.sql.go
+++ b/pkg/db/subscription.sql.go
@@ -212,6 +212,54 @@ func (q *Queries) GetNotificationByUUID(ctx context.Context, notificationUuid uu
 	return i, err
 }
 
+const getNotificationDataByAccountAndServiceAndSeriesStartdate = `-- name: GetNotificationDataByAccountAndServiceAndSeriesStartdate :many
+SELECT notification_data_uuid, account_uuid, notification_uuid, service, data, fetched_at
+FROM notification_data
+WHERE account_uuid = $1
+  AND service = $2
+  AND data -> 'body' -> 'series' @> jsonb_build_array(jsonb_build_object('startdate', $3::bigint))
+ORDER BY fetched_at DESC
+LIMIT 1
+`
+
+type GetNotificationDataByAccountAndServiceAndSeriesStartdateParams struct {
+	AccountUuid uuid.UUID
+	Service     string
+	Startdate   int64
+}
+
+// Returns notification_data rows whose JSONB body.series array contains an
+// entry with the requested startdate. Used by the sleep detail page so the
+// Getsummary-by-startdate lookup is a single indexed query rather than
+// "fetch every summary and filter in Go". Backed by the GIN index
+// notification_data_body_series_idx.
+func (q *Queries) GetNotificationDataByAccountAndServiceAndSeriesStartdate(ctx context.Context, arg GetNotificationDataByAccountAndServiceAndSeriesStartdateParams) ([]NotificationDatum, error) {
+	rows, err := q.db.Query(ctx, getNotificationDataByAccountAndServiceAndSeriesStartdate, arg.AccountUuid, arg.Service, arg.Startdate)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []NotificationDatum
+	for rows.Next() {
+		var i NotificationDatum
+		if err := rows.Scan(
+			&i.NotificationDataUuid,
+			&i.AccountUuid,
+			&i.NotificationUuid,
+			&i.Service,
+			&i.Data,
+			&i.FetchedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getNotificationDataByAccountUUIDAndService = `-- name: GetNotificationDataByAccountUUIDAndService :many
 SELECT notification_data_uuid, account_uuid, notification_uuid, service, data, fetched_at
 FROM notification_data

--- a/pkg/db/subscription.sql.go
+++ b/pkg/db/subscription.sql.go
@@ -212,6 +212,46 @@ func (q *Queries) GetNotificationByUUID(ctx context.Context, notificationUuid uu
 	return i, err
 }
 
+const getNotificationDataByAccountUUIDAndService = `-- name: GetNotificationDataByAccountUUIDAndService :many
+SELECT notification_data_uuid, account_uuid, notification_uuid, service, data, fetched_at
+FROM notification_data
+WHERE account_uuid = $1
+  AND service = $2
+ORDER BY fetched_at DESC
+`
+
+type GetNotificationDataByAccountUUIDAndServiceParams struct {
+	AccountUuid uuid.UUID
+	Service     string
+}
+
+func (q *Queries) GetNotificationDataByAccountUUIDAndService(ctx context.Context, arg GetNotificationDataByAccountUUIDAndServiceParams) ([]NotificationDatum, error) {
+	rows, err := q.db.Query(ctx, getNotificationDataByAccountUUIDAndService, arg.AccountUuid, arg.Service)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []NotificationDatum
+	for rows.Next() {
+		var i NotificationDatum
+		if err := rows.Scan(
+			&i.NotificationDataUuid,
+			&i.AccountUuid,
+			&i.NotificationUuid,
+			&i.Service,
+			&i.Data,
+			&i.FetchedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getNotificationDataByNotificationUUID = `-- name: GetNotificationDataByNotificationUUID :many
 SELECT notification_data_uuid, account_uuid, notification_uuid, service, data, fetched_at
 FROM notification_data

--- a/pkg/domain/entities/sleepsummary.go
+++ b/pkg/domain/entities/sleepsummary.go
@@ -9,6 +9,7 @@ type SleepSummaries []SleepSummary
 
 type SleepSummary struct {
 	Date           civil.Date
+	Startdate      int64
 	SleepScore     *float64
 	TotalSleepTime *time.Duration
 	RawResponse    string

--- a/pkg/migration/000011_notification_data_indexes.up.sql
+++ b/pkg/migration/000011_notification_data_indexes.up.sql
@@ -1,0 +1,11 @@
+-- Supports GetNotificationDataByAccountUUIDAndService — turns the per-page
+-- (account_uuid, service) lookup from a sequential scan into an index range.
+create index if not exists notification_data_account_service_fetched_idx
+    on notification_data (account_uuid, service, fetched_at desc);
+
+-- Supports JSONB containment on body.series, used by the sleep detail page
+-- to find a Sleep v2 - Getsummary row by an exact session startdate without
+-- pulling and parsing every stored summary in Go. jsonb_path_ops only
+-- supports @> which is what the lookup uses.
+create index if not exists notification_data_body_series_idx
+    on notification_data using gin ((data -> 'body' -> 'series') jsonb_path_ops);

--- a/pkg/service/sleep/sleep.go
+++ b/pkg/service/sleep/sleep.go
@@ -90,6 +90,7 @@ func (sleepSvc *Sleep) GetSleepSummaries(
 		if err != nil {
 			log.WithError(err).WithField("event", "warn.sleepsummary.parsedate").Warn()
 		}
+		sleepSummary.Startdate = int64(sleep.Startdate)
 		sleepSummary.SleepScore = &sleep.Data.SleepScore
 		duration := time.Second * time.Duration(sleep.Data.TotalSleepTime)
 		sleepSummary.TotalSleepTime = &duration

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -34,6 +34,7 @@ func Router(svc *app.App) *mux.Router {
 	s.HandleFunc("/auth/refresh", port.RefreshWithingsAccessToken(svc))
 
 	s.HandleFunc("/sleepsummaries", port.SleepSummaries(svc))
+	s.Path("/sleepsessions/{startdate:[0-9]+}").Methods("GET").Handler(port.SleepSession(svc))
 	//r.HandleFunc("/sleepget.json", handlers.SleepGetJSON(svc))
 	s.Path("/subscriptions").Methods("GET").Handler(port.SubscriptionsPage(svc))
 	s.Path("/subscriptions/withings").Methods("GET").Handler(port.SubscriptionsWithingsPage(svc))

--- a/pkg/web/templates/templates.go
+++ b/pkg/web/templates/templates.go
@@ -125,10 +125,46 @@ func (t *Templates) RenderRefreshAccessToken(ctx context.Context, w io.Writer, t
 type SleepSessionVars struct {
 	Context TemplateContext
 	Error   string
-	View    interface{}
+	View    SleepSessionView
 }
 
-func (t *Templates) RenderSleepSession(ctx context.Context, w io.Writer, view interface{}) error {
+// SleepSessionView mirrors port.SleepSessionView. Defined here so the templates
+// package isn't import-cycled with port. The port handler builds its own
+// SleepSessionView and we copy the fields over for rendering.
+type SleepSessionView struct {
+	Found     bool
+	Startdate int64
+
+	Date          string
+	Timezone      string
+	StartLocal    string
+	EndLocal      string
+	DurationStr   string
+	SleepScore    int
+	Efficiency    int
+	Light         string
+	Deep          string
+	REM           string
+	Awake         string
+	HRMin         int
+	HRAvg         int
+	HRMax         int
+	RRMin         int
+	RRAvg         int
+	RRMax         int
+	BreathingDist int
+	Snoring       string
+	SnoringCount  int
+	AHI           float64
+
+	Hypnogram    template.HTML
+	HRChart      template.HTML
+	RRChart      template.HTML
+	HRVChart     template.HTML
+	SnoringChart template.HTML
+}
+
+func (t *Templates) RenderSleepSession(ctx context.Context, w io.Writer, view SleepSessionView) error {
 	tmpl, err := template.New("base.gohtml").ParseFS(t.FS, "base.gohtml", "sleepsession.gohtml")
 	if err != nil {
 		panic(err.Error())

--- a/pkg/web/templates/templates.go
+++ b/pkg/web/templates/templates.go
@@ -122,6 +122,24 @@ func (t *Templates) RenderRefreshAccessToken(ctx context.Context, w io.Writer, t
 	})
 }
 
+type SleepSessionVars struct {
+	Context TemplateContext
+	Error   string
+	View    interface{}
+}
+
+func (t *Templates) RenderSleepSession(ctx context.Context, w io.Writer, view interface{}) error {
+	tmpl, err := template.New("base.gohtml").ParseFS(t.FS, "base.gohtml", "sleepsession.gohtml")
+	if err != nil {
+		panic(err.Error())
+	}
+	tmpl.Option("missingkey=error")
+	return tmpl.ExecuteTemplate(w, "base.gohtml", SleepSessionVars{
+		Context: extractTemplateContext(ctx),
+		View:    view,
+	})
+}
+
 type SleepSummariesVars struct {
 	SleepData interface{}
 	Token     *withings.Token

--- a/pkg/web/templates/templates/sleepsession.gohtml
+++ b/pkg/web/templates/templates/sleepsession.gohtml
@@ -1,0 +1,106 @@
+{{define "title"}}Sleep session{{end}}
+
+{{define "content"}}
+  <style>
+    svg.sleepviz { width: 100%; max-width: 800px; height: auto; display: block; margin-bottom: 1rem; background: #fafafa; border: 1px solid #eee; }
+  </style>
+
+  <p><a href="/sleepsummaries">&larr; Back to 30-day sleep</a></p>
+
+  {{ with .View }}
+    {{ if not .Found }}
+      <article class="message is-warning">
+        <div class="message-header"><p>No stored data for this session</p></div>
+        <div class="message-body">
+          The detail page reads from notification data fetched via webhooks. We have no
+          stored <code>Sleep v2 - Getsummary</code> entry with startdate {{ .Startdate }}.
+        </div>
+      </article>
+    {{ else }}
+      <h1 class="title is-4">Sleep session — {{ .Date }}</h1>
+      <p class="subtitle is-6">{{ .StartLocal }} → {{ .EndLocal }} ({{ .Timezone }})</p>
+
+      <div class="columns is-multiline">
+        <div class="column is-3">
+          <div class="box">
+            <p class="heading">Sleep score</p>
+            <p class="title">{{ .SleepScore }}</p>
+            <progress class="progress is-info" value="{{ .SleepScore }}" max="100">{{ .SleepScore }}</progress>
+          </div>
+        </div>
+        <div class="column is-3">
+          <div class="box">
+            <p class="heading">Total sleep</p>
+            <p class="title is-5">{{ .DurationStr }}</p>
+            <p>Efficiency {{ .Efficiency }}%</p>
+          </div>
+        </div>
+        <div class="column is-3">
+          <div class="box">
+            <p class="heading">Heart rate</p>
+            <p class="title is-5">{{ .HRAvg }} bpm</p>
+            <p>min {{ .HRMin }} · max {{ .HRMax }}</p>
+          </div>
+        </div>
+        <div class="column is-3">
+          <div class="box">
+            <p class="heading">Respiration</p>
+            <p class="title is-5">{{ .RRAvg }} rpm</p>
+            <p>min {{ .RRMin }} · max {{ .RRMax }}</p>
+          </div>
+        </div>
+        <div class="column is-3">
+          <div class="box">
+            <p class="heading">Light sleep</p>
+            <p class="title is-6">{{ .Light }}</p>
+          </div>
+        </div>
+        <div class="column is-3">
+          <div class="box">
+            <p class="heading">Deep sleep</p>
+            <p class="title is-6">{{ .Deep }}</p>
+          </div>
+        </div>
+        <div class="column is-3">
+          <div class="box">
+            <p class="heading">REM</p>
+            <p class="title is-6">{{ .REM }}</p>
+          </div>
+        </div>
+        <div class="column is-3">
+          <div class="box">
+            <p class="heading">Awake</p>
+            <p class="title is-6">{{ .Awake }}</p>
+          </div>
+        </div>
+        <div class="column is-3">
+          <div class="box">
+            <p class="heading">Snoring</p>
+            <p class="title is-6">{{ .Snoring }}</p>
+            <p>{{ .SnoringCount }} episodes</p>
+          </div>
+        </div>
+        <div class="column is-3">
+          <div class="box">
+            <p class="heading">AHI</p>
+            <p class="title is-6">{{ printf "%.1f" .AHI }}</p>
+          </div>
+        </div>
+        <div class="column is-3">
+          <div class="box">
+            <p class="heading">Breathing disturbances</p>
+            <p class="title is-6">{{ .BreathingDist }}</p>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        {{ .Hypnogram }}
+        {{ .HRChart }}
+        {{ .RRChart }}
+        {{ .HRVChart }}
+        {{ .Snoring01 }}
+      </div>
+    {{ end }}
+  {{ end }}
+{{end}}

--- a/pkg/web/templates/templates/sleepsession.gohtml
+++ b/pkg/web/templates/templates/sleepsession.gohtml
@@ -99,7 +99,7 @@
         {{ .HRChart }}
         {{ .RRChart }}
         {{ .HRVChart }}
-        {{ .Snoring01 }}
+        {{ .SnoringChart }}
       </div>
     {{ end }}
   {{ end }}

--- a/pkg/web/templates/templates/sleepsummaries.gohtml
+++ b/pkg/web/templates/templates/sleepsummaries.gohtml
@@ -48,7 +48,7 @@
       <tbody>
       {{ range $_, $value := .SleepData.Summaries }}
         <tr>
-          <td>{{ $value.Date }}</td>
+          <td><a href="/sleepsessions/{{ $value.Startdate }}">{{ $value.Date }}</a></td>
           <td>{{ $value.TotalSleepTime }}</td>
           <td>{{ $value.SleepScore }}</td>
           <td>

--- a/pkg/withoutings/adapter/subscription/subscription_pg_repo.go
+++ b/pkg/withoutings/adapter/subscription/subscription_pg_repo.go
@@ -456,6 +456,17 @@ func (r PgRepo) GetNotificationDataByNotificationUUID(ctx context.Context, notif
 	return toDomainNotificationData(dbNotificationData)
 }
 
+func (r PgRepo) GetNotificationDataByAccountUUIDAndService(ctx context.Context, accountUUID uuid.UUID, service subscription.NotificationDataService) ([]*subscription.NotificationData, error) {
+	dbNotificationData, err := r.queries.GetNotificationDataByAccountUUIDAndService(ctx, db.GetNotificationDataByAccountUUIDAndServiceParams{
+		AccountUuid: accountUUID,
+		Service:     string(service),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return toDomainNotificationData(dbNotificationData)
+}
+
 func toDomainNotificationDatum(dbNotificationData db.NotificationDatum) (*subscription.NotificationData, error) {
 	service, err := subscription.NewNotificationDataService(dbNotificationData.Service)
 	if err != nil {

--- a/pkg/withoutings/adapter/subscription/subscription_pg_repo.go
+++ b/pkg/withoutings/adapter/subscription/subscription_pg_repo.go
@@ -467,6 +467,21 @@ func (r PgRepo) GetNotificationDataByAccountUUIDAndService(ctx context.Context, 
 	return toDomainNotificationData(dbNotificationData)
 }
 
+func (r PgRepo) GetNotificationDataByAccountAndServiceAndSeriesStartdate(ctx context.Context, accountUUID uuid.UUID, service subscription.NotificationDataService, startdate int64) (*subscription.NotificationData, error) {
+	dbRows, err := r.queries.GetNotificationDataByAccountAndServiceAndSeriesStartdate(ctx, db.GetNotificationDataByAccountAndServiceAndSeriesStartdateParams{
+		AccountUuid: accountUUID,
+		Service:     string(service),
+		Startdate:   startdate,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(dbRows) == 0 {
+		return nil, nil
+	}
+	return toDomainNotificationDatum(dbRows[0])
+}
+
 func toDomainNotificationDatum(dbNotificationData db.NotificationDatum) (*subscription.NotificationData, error) {
 	service, err := subscription.NewNotificationDataService(dbNotificationData.Service)
 	if err != nil {

--- a/pkg/withoutings/domain/subscription/subscriptionrepo.go
+++ b/pkg/withoutings/domain/subscription/subscriptionrepo.go
@@ -34,4 +34,5 @@ type Repo interface {
 	StoreNotificationData(ctx context.Context, notificationData *NotificationData) error
 	GetNotificationDataByNotificationUUID(ctx context.Context, notificationUUID uuid.UUID) ([]*NotificationData, error)
 	GetNotificationDataByAccountUUIDAndService(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService) ([]*NotificationData, error)
+	GetNotificationDataByAccountAndServiceAndSeriesStartdate(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService, startdate int64) (*NotificationData, error)
 }

--- a/pkg/withoutings/domain/subscription/subscriptionrepo.go
+++ b/pkg/withoutings/domain/subscription/subscriptionrepo.go
@@ -33,4 +33,5 @@ type Repo interface {
 	UpdateNotification(ctx context.Context, notificationUUID uuid.UUID, updateFn func(ctx context.Context, notification *Notification) (*Notification, error)) error
 	StoreNotificationData(ctx context.Context, notificationData *NotificationData) error
 	GetNotificationDataByNotificationUUID(ctx context.Context, notificationUUID uuid.UUID) ([]*NotificationData, error)
+	GetNotificationDataByAccountUUIDAndService(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService) ([]*NotificationData, error)
 }

--- a/pkg/withoutings/domain/subscription/subscriptionrepo_mock.go
+++ b/pkg/withoutings/domain/subscription/subscriptionrepo_mock.go
@@ -396,6 +396,80 @@ func (_c *MockRepo_GetNotificationByUUID_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
+// GetNotificationDataByAccountUUIDAndService provides a mock function for the type MockRepo
+func (_mock *MockRepo) GetNotificationDataByAccountUUIDAndService(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService) ([]*NotificationData, error) {
+	ret := _mock.Called(ctx, accountUUID, service)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNotificationDataByAccountUUIDAndService")
+	}
+
+	var r0 []*NotificationData
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, NotificationDataService) ([]*NotificationData, error)); ok {
+		return returnFunc(ctx, accountUUID, service)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, NotificationDataService) []*NotificationData); ok {
+		r0 = returnFunc(ctx, accountUUID, service)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*NotificationData)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, NotificationDataService) error); ok {
+		r1 = returnFunc(ctx, accountUUID, service)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepo_GetNotificationDataByAccountUUIDAndService_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNotificationDataByAccountUUIDAndService'
+type MockRepo_GetNotificationDataByAccountUUIDAndService_Call struct {
+	*mock.Call
+}
+
+// GetNotificationDataByAccountUUIDAndService is a helper method to define mock.On call
+//   - ctx context.Context
+//   - accountUUID uuid.UUID
+//   - service NotificationDataService
+func (_e *MockRepo_Expecter) GetNotificationDataByAccountUUIDAndService(ctx interface{}, accountUUID interface{}, service interface{}) *MockRepo_GetNotificationDataByAccountUUIDAndService_Call {
+	return &MockRepo_GetNotificationDataByAccountUUIDAndService_Call{Call: _e.mock.On("GetNotificationDataByAccountUUIDAndService", ctx, accountUUID, service)}
+}
+
+func (_c *MockRepo_GetNotificationDataByAccountUUIDAndService_Call) Run(run func(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService)) *MockRepo_GetNotificationDataByAccountUUIDAndService_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uuid.UUID
+		if args[1] != nil {
+			arg1 = args[1].(uuid.UUID)
+		}
+		var arg2 NotificationDataService
+		if args[2] != nil {
+			arg2 = args[2].(NotificationDataService)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepo_GetNotificationDataByAccountUUIDAndService_Call) Return(notificationDatas []*NotificationData, err error) *MockRepo_GetNotificationDataByAccountUUIDAndService_Call {
+	_c.Call.Return(notificationDatas, err)
+	return _c
+}
+
+func (_c *MockRepo_GetNotificationDataByAccountUUIDAndService_Call) RunAndReturn(run func(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService) ([]*NotificationData, error)) *MockRepo_GetNotificationDataByAccountUUIDAndService_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNotificationDataByNotificationUUID provides a mock function for the type MockRepo
 func (_mock *MockRepo) GetNotificationDataByNotificationUUID(ctx context.Context, notificationUUID uuid.UUID) ([]*NotificationData, error) {
 	ret := _mock.Called(ctx, notificationUUID)

--- a/pkg/withoutings/domain/subscription/subscriptionrepo_mock.go
+++ b/pkg/withoutings/domain/subscription/subscriptionrepo_mock.go
@@ -396,6 +396,86 @@ func (_c *MockRepo_GetNotificationByUUID_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
+// GetNotificationDataByAccountAndServiceAndSeriesStartdate provides a mock function for the type MockRepo
+func (_mock *MockRepo) GetNotificationDataByAccountAndServiceAndSeriesStartdate(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService, startdate int64) (*NotificationData, error) {
+	ret := _mock.Called(ctx, accountUUID, service, startdate)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNotificationDataByAccountAndServiceAndSeriesStartdate")
+	}
+
+	var r0 *NotificationData
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, NotificationDataService, int64) (*NotificationData, error)); ok {
+		return returnFunc(ctx, accountUUID, service, startdate)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, NotificationDataService, int64) *NotificationData); ok {
+		r0 = returnFunc(ctx, accountUUID, service, startdate)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*NotificationData)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, NotificationDataService, int64) error); ok {
+		r1 = returnFunc(ctx, accountUUID, service, startdate)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepo_GetNotificationDataByAccountAndServiceAndSeriesStartdate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNotificationDataByAccountAndServiceAndSeriesStartdate'
+type MockRepo_GetNotificationDataByAccountAndServiceAndSeriesStartdate_Call struct {
+	*mock.Call
+}
+
+// GetNotificationDataByAccountAndServiceAndSeriesStartdate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - accountUUID uuid.UUID
+//   - service NotificationDataService
+//   - startdate int64
+func (_e *MockRepo_Expecter) GetNotificationDataByAccountAndServiceAndSeriesStartdate(ctx interface{}, accountUUID interface{}, service interface{}, startdate interface{}) *MockRepo_GetNotificationDataByAccountAndServiceAndSeriesStartdate_Call {
+	return &MockRepo_GetNotificationDataByAccountAndServiceAndSeriesStartdate_Call{Call: _e.mock.On("GetNotificationDataByAccountAndServiceAndSeriesStartdate", ctx, accountUUID, service, startdate)}
+}
+
+func (_c *MockRepo_GetNotificationDataByAccountAndServiceAndSeriesStartdate_Call) Run(run func(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService, startdate int64)) *MockRepo_GetNotificationDataByAccountAndServiceAndSeriesStartdate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uuid.UUID
+		if args[1] != nil {
+			arg1 = args[1].(uuid.UUID)
+		}
+		var arg2 NotificationDataService
+		if args[2] != nil {
+			arg2 = args[2].(NotificationDataService)
+		}
+		var arg3 int64
+		if args[3] != nil {
+			arg3 = args[3].(int64)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepo_GetNotificationDataByAccountAndServiceAndSeriesStartdate_Call) Return(notificationData *NotificationData, err error) *MockRepo_GetNotificationDataByAccountAndServiceAndSeriesStartdate_Call {
+	_c.Call.Return(notificationData, err)
+	return _c
+}
+
+func (_c *MockRepo_GetNotificationDataByAccountAndServiceAndSeriesStartdate_Call) RunAndReturn(run func(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService, startdate int64) (*NotificationData, error)) *MockRepo_GetNotificationDataByAccountAndServiceAndSeriesStartdate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNotificationDataByAccountUUIDAndService provides a mock function for the type MockRepo
 func (_mock *MockRepo) GetNotificationDataByAccountUUIDAndService(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService) ([]*NotificationData, error) {
 	ret := _mock.Called(ctx, accountUUID, service)

--- a/pkg/withoutings/port/sleep_session.go
+++ b/pkg/withoutings/port/sleep_session.go
@@ -1,0 +1,491 @@
+package port
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/roessland/withoutings/pkg/logging"
+	"github.com/roessland/withoutings/pkg/withoutings/app"
+	"github.com/roessland/withoutings/pkg/withoutings/domain/account"
+	"github.com/roessland/withoutings/pkg/withoutings/domain/subscription"
+	"github.com/roessland/withoutings/pkg/withoutings/domain/withings"
+)
+
+// SleepSession renders detailed visualizations for a single sleep session.
+// The session is identified by its Withings `startdate` (Unix seconds).
+// Data is read from notification_data populated by appli=44 webhooks; if no
+// matching session is stored for the user, a "no data" message is shown.
+//
+// Methods: GET
+func SleepSession(svc *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		log := logging.MustGetLoggerFromContext(ctx)
+
+		acc := account.GetFromContext(ctx)
+		if acc == nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, "You must be logged in to view this page.")
+			return
+		}
+
+		startdate, err := strconv.ParseInt(mux.Vars(r)["startdate"], 10, 64)
+		if err != nil {
+			http.Error(w, "invalid startdate", http.StatusBadRequest)
+			return
+		}
+
+		view, err := buildSleepSessionView(ctx, svc.SubscriptionRepo, acc.UUID(), startdate)
+		if err != nil {
+			log.WithError(err).WithField("event", "error.SleepSession.build").Error()
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		if err := svc.Templates.RenderSleepSession(ctx, w, view); err != nil {
+			log.WithError(err).WithField("event", "error.SleepSession.render").Error()
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+// buildSleepSessionView locates the matching Sleep v2 - Getsummary entry by
+// startdate, gathers Sleep v2 - Get segments inside the session window, and
+// produces a render-ready view with prebuilt inline SVGs.
+func buildSleepSessionView(
+	ctx context.Context,
+	repo subscription.Repo,
+	accountUUID uuid.UUID,
+	startdate int64,
+) (SleepSessionView, error) {
+	view := SleepSessionView{Startdate: startdate}
+
+	summaryRows, err := repo.GetNotificationDataByAccountUUIDAndService(ctx, accountUUID, subscription.NotificationDataServiceSleepv2Getsummary)
+	if err != nil {
+		return view, fmt.Errorf("get summary rows: %w", err)
+	}
+
+	var summary withings.SleepGetsummaryEntry
+	var summaryFound bool
+	for _, row := range summaryRows {
+		var resp withings.SleepGetsummaryResponse
+		if err := json.Unmarshal(row.Data(), &resp); err != nil {
+			continue
+		}
+		for _, entry := range resp.Body.Series {
+			if int64(entry.Startdate) == startdate {
+				summary = entry
+				summaryFound = true
+				break
+			}
+		}
+		if summaryFound {
+			break
+		}
+	}
+	if !summaryFound {
+		return view, nil
+	}
+	view.Found = true
+	view.populateSummary(summary)
+
+	// Pull all Sleep v2 - Get rows for the account; segments overlapping the
+	// session window contribute to the charts. Withings webhooks can deliver
+	// data spanning multiple sessions, so we filter inside.
+	getRows, err := repo.GetNotificationDataByAccountUUIDAndService(ctx, accountUUID, subscription.NotificationDataServiceSleepv2Get)
+	if err != nil {
+		return view, fmt.Errorf("get sleep-get rows: %w", err)
+	}
+
+	sessionStart := int64(summary.Startdate)
+	sessionEnd := int64(summary.Enddate)
+	var segments []withings.SleepGetEntry
+	seen := make(map[string]bool)
+	for _, row := range getRows {
+		var resp withings.SleepGetResponse
+		if err := json.Unmarshal(row.Data(), &resp); err != nil {
+			continue
+		}
+		for _, seg := range resp.Body.Series {
+			if seg.Enddate <= sessionStart || seg.Startdate >= sessionEnd {
+				continue
+			}
+			key := fmt.Sprintf("%d-%d-%d", seg.Startdate, seg.Enddate, seg.State)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			segments = append(segments, seg)
+		}
+	}
+	sort.Slice(segments, func(i, j int) bool {
+		return segments[i].Startdate < segments[j].Startdate
+	})
+
+	view.buildCharts(segments, sessionStart, sessionEnd, summary.Timezone)
+	return view, nil
+}
+
+// SleepSessionView is the render-ready struct for the sleep detail template.
+type SleepSessionView struct {
+	Found     bool
+	Startdate int64
+
+	Date          string
+	Timezone      string
+	StartLocal    string
+	EndLocal      string
+	DurationStr   string
+	SleepScore    int
+	Efficiency    int    // 0–100
+	Light         string // "2h 21m"
+	Deep          string
+	REM           string
+	Awake         string
+	HRMin         int
+	HRAvg         int
+	HRMax         int
+	RRMin         int
+	RRAvg         int
+	RRMax         int
+	BreathingDist int
+	Snoring       string
+	SnoringCount  int
+	AHI           float64
+
+	Hypnogram template.HTML
+	HRChart   template.HTML
+	RRChart   template.HTML
+	HRVChart  template.HTML
+	Snoring01 template.HTML
+}
+
+func (v *SleepSessionView) populateSummary(s withings.SleepGetsummaryEntry) {
+	v.Date = s.Date
+	v.Timezone = s.Timezone
+
+	loc, err := time.LoadLocation(s.Timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	startT := time.Unix(int64(s.Startdate), 0).In(loc)
+	endT := time.Unix(int64(s.Enddate), 0).In(loc)
+	v.StartLocal = startT.Format("15:04")
+	v.EndLocal = endT.Format("15:04")
+	v.DurationStr = formatDuration(time.Duration(s.Data.TotalSleepTime) * time.Second)
+
+	v.SleepScore = int(s.Data.SleepScore)
+	v.Efficiency = int(s.Data.SleepEfficiency * 100)
+	v.Light = formatDuration(time.Duration(s.Data.Lightsleepduration) * time.Second)
+	v.Deep = formatDuration(time.Duration(s.Data.Deepsleepduration) * time.Second)
+	v.REM = formatDuration(time.Duration(s.Data.Remsleepduration) * time.Second)
+	v.Awake = formatDuration(time.Duration(s.Data.Wakeupduration) * time.Second)
+	v.HRMin = int(s.Data.HrMin)
+	v.HRAvg = int(s.Data.HrAverage)
+	v.HRMax = int(s.Data.HrMax)
+	v.RRMin = int(s.Data.RrMin)
+	v.RRAvg = int(s.Data.RrAverage)
+	v.RRMax = int(s.Data.RrMax)
+	v.BreathingDist = int(s.Data.BreathingDisturbancesIntensity)
+	v.Snoring = formatDuration(time.Duration(s.Data.Snoring) * time.Second)
+	v.SnoringCount = s.Data.Snoringepisodecount
+	v.AHI = s.Data.ApneaHypopneaIndex
+}
+
+func formatDuration(d time.Duration) string {
+	if d <= 0 {
+		return "0m"
+	}
+	h := int(d / time.Hour)
+	m := int((d % time.Hour) / time.Minute)
+	if h == 0 {
+		return fmt.Sprintf("%dm", m)
+	}
+	return fmt.Sprintf("%dh %02dm", h, m)
+}
+
+// timePoint is a single (unix-second, value) sample.
+type timePoint struct {
+	t int64
+	v float64
+}
+
+const (
+	chartW         = 800
+	chartH         = 120
+	hypnoH         = 90
+	chartMarginX   = 40
+	chartMarginTop = 14
+	chartMarginBot = 22
+)
+
+// buildCharts assembles the inline SVGs from the session segments.
+func (v *SleepSessionView) buildCharts(segments []withings.SleepGetEntry, sessionStart, sessionEnd int64, tz string) {
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		loc = time.UTC
+	}
+
+	var hr, rr, sdnn, rmssd, snoring []timePoint
+	for _, seg := range segments {
+		hr = append(hr, decodeSamples(seg.HR)...)
+		rr = append(rr, decodeSamples(seg.RR)...)
+		sdnn = append(sdnn, decodeSamples(seg.SDNN1)...)
+		rmssd = append(rmssd, decodeSamples(seg.RMSSD)...)
+		snoring = append(snoring, decodeSamples(seg.Snoring)...)
+	}
+	sortPoints(hr)
+	sortPoints(rr)
+	sortPoints(sdnn)
+	sortPoints(rmssd)
+	sortPoints(snoring)
+
+	v.Hypnogram = template.HTML(buildHypnogramSVG(segments, sessionStart, sessionEnd, loc))
+	v.HRChart = template.HTML(buildLineChartSVG("Heart rate (bpm)", hr, sessionStart, sessionEnd, loc, "#e91e63"))
+	v.RRChart = template.HTML(buildLineChartSVG("Respiratory rate (rpm)", rr, sessionStart, sessionEnd, loc, "#3f51b5"))
+	v.HRVChart = template.HTML(buildDualLineChartSVG("HRV (sdnn_1, rmssd)", sdnn, rmssd, sessionStart, sessionEnd, loc, "#009688", "#ff9800"))
+	v.Snoring01 = template.HTML(buildSnoringSVG("Snoring (s/min)", snoring, sessionStart, sessionEnd, loc))
+}
+
+func decodeSamples(raw []byte) []timePoint {
+	if len(raw) == 0 {
+		return nil
+	}
+	var m map[string]float64
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil
+	}
+	out := make([]timePoint, 0, len(m))
+	for k, val := range m {
+		ts, err := strconv.ParseInt(k, 10, 64)
+		if err != nil {
+			continue
+		}
+		out = append(out, timePoint{t: ts, v: val})
+	}
+	return out
+}
+
+func sortPoints(p []timePoint) {
+	sort.Slice(p, func(i, j int) bool { return p[i].t < p[j].t })
+}
+
+// stateColors maps Withings sleep states to display colors.
+//
+//	0 = awake, 1 = light, 2 = deep, 3 = REM
+var stateColors = map[int]string{
+	0: "#bdbdbd",
+	1: "#90caf9",
+	2: "#1565c0",
+	3: "#ab47bc",
+}
+
+var stateLabels = map[int]string{
+	0: "Awake",
+	1: "Light",
+	2: "Deep",
+	3: "REM",
+}
+
+func buildHypnogramSVG(segments []withings.SleepGetEntry, start, end int64, loc *time.Location) string {
+	if end <= start {
+		return ""
+	}
+	span := float64(end - start)
+	innerW := float64(chartW - 2*chartMarginX)
+	x := func(t int64) float64 {
+		if t < start {
+			t = start
+		}
+		if t > end {
+			t = end
+		}
+		return float64(chartMarginX) + (float64(t-start)/span)*innerW
+	}
+	bandTop := chartMarginTop
+	bandBot := hypnoH - chartMarginBot
+
+	var b strings.Builder
+	fmt.Fprintf(&b, `<svg viewBox="0 0 %d %d" class="sleepviz">`, chartW, hypnoH)
+	fmt.Fprintf(&b, `<text x="8" y="14" font-size="11" fill="#555">Hypnogram</text>`)
+	for _, seg := range segments {
+		color, ok := stateColors[seg.State]
+		if !ok {
+			color = "#cccccc"
+		}
+		segStart := seg.Startdate
+		if segStart < start {
+			segStart = start
+		}
+		segEnd := seg.Enddate
+		if segEnd > end {
+			segEnd = end
+		}
+		if segEnd <= segStart {
+			continue
+		}
+		x0 := x(segStart)
+		x1 := x(segEnd)
+		fmt.Fprintf(&b, `<rect x="%.1f" y="%d" width="%.1f" height="%d" fill="%s"><title>%s %s–%s</title></rect>`,
+			x0, bandTop, x1-x0, bandBot-bandTop, color,
+			stateLabels[seg.State],
+			time.Unix(segStart, 0).In(loc).Format("15:04"),
+			time.Unix(segEnd, 0).In(loc).Format("15:04"),
+		)
+	}
+	writeTimeAxis(&b, start, end, loc, hypnoH-chartMarginBot+12)
+	writeLegend(&b, chartW)
+	b.WriteString(`</svg>`)
+	return b.String()
+}
+
+func writeLegend(b *strings.Builder, w int) {
+	x := w - 240
+	for i := 0; i < 4; i++ {
+		fmt.Fprintf(b, `<rect x="%d" y="2" width="10" height="10" fill="%s"/>`, x, stateColors[i])
+		fmt.Fprintf(b, `<text x="%d" y="11" font-size="10" fill="#444">%s</text>`, x+13, stateLabels[i])
+		x += 60
+	}
+}
+
+func writeTimeAxis(b *strings.Builder, start, end int64, loc *time.Location, y int) {
+	if end <= start {
+		return
+	}
+	span := float64(end - start)
+	innerW := float64(chartW - 2*chartMarginX)
+	startT := time.Unix(start, 0).In(loc).Truncate(time.Hour).Add(time.Hour)
+	endT := time.Unix(end, 0).In(loc)
+	for t := startT; !t.After(endT); t = t.Add(time.Hour) {
+		ts := t.Unix()
+		if ts <= start || ts >= end {
+			continue
+		}
+		x := float64(chartMarginX) + (float64(ts-start)/span)*innerW
+		fmt.Fprintf(b, `<line x1="%.1f" y1="%d" x2="%.1f" y2="%d" stroke="#ddd"/>`, x, chartMarginTop, x, y-12)
+		fmt.Fprintf(b, `<text x="%.1f" y="%d" font-size="10" text-anchor="middle" fill="#666">%s</text>`, x, y, t.Format("15:04"))
+	}
+}
+
+func buildLineChartSVG(title string, points []timePoint, start, end int64, loc *time.Location, color string) string {
+	return buildDualLineChartSVG(title, points, nil, start, end, loc, color, "")
+}
+
+func buildDualLineChartSVG(title string, a, b []timePoint, start, end int64, loc *time.Location, colorA, colorB string) string {
+	if end <= start {
+		return ""
+	}
+	all := make([]timePoint, 0, len(a)+len(b))
+	all = append(all, a...)
+	all = append(all, b...)
+	if len(all) == 0 {
+		return emptyChartSVG(title)
+	}
+	yMin, yMax := all[0].v, all[0].v
+	for _, p := range all {
+		if p.v < yMin {
+			yMin = p.v
+		}
+		if p.v > yMax {
+			yMax = p.v
+		}
+	}
+	if yMax == yMin {
+		yMax = yMin + 1
+	}
+	span := float64(end - start)
+	innerW := float64(chartW - 2*chartMarginX)
+	innerH := float64(chartH - chartMarginTop - chartMarginBot)
+	xPos := func(t int64) float64 {
+		return float64(chartMarginX) + (float64(t-start)/span)*innerW
+	}
+	yPos := func(v float64) float64 {
+		return float64(chartMarginTop) + (1-(v-yMin)/(yMax-yMin))*innerH
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, `<svg viewBox="0 0 %d %d" class="sleepviz">`, chartW, chartH)
+	fmt.Fprintf(&sb, `<text x="8" y="14" font-size="11" fill="#555">%s</text>`, template.HTMLEscapeString(title))
+	fmt.Fprintf(&sb, `<text x="%d" y="%.1f" font-size="10" fill="#888" text-anchor="end">%.0f</text>`, chartMarginX-4, yPos(yMax)+3, yMax)
+	fmt.Fprintf(&sb, `<text x="%d" y="%.1f" font-size="10" fill="#888" text-anchor="end">%.0f</text>`, chartMarginX-4, yPos(yMin)+3, yMin)
+	writePolyline(&sb, a, xPos, yPos, colorA, start, end)
+	if colorB != "" {
+		writePolyline(&sb, b, xPos, yPos, colorB, start, end)
+	}
+	writeTimeAxis(&sb, start, end, loc, chartH-chartMarginBot+12)
+	sb.WriteString(`</svg>`)
+	return sb.String()
+}
+
+func writePolyline(b *strings.Builder, points []timePoint, xPos func(int64) float64, yPos func(float64) float64, color string, start, end int64) {
+	if len(points) == 0 || color == "" {
+		return
+	}
+	var sb strings.Builder
+	first := true
+	for _, p := range points {
+		if p.t < start || p.t > end {
+			continue
+		}
+		if !first {
+			sb.WriteByte(' ')
+		}
+		first = false
+		fmt.Fprintf(&sb, "%.1f,%.1f", xPos(p.t), yPos(p.v))
+	}
+	if first {
+		return
+	}
+	fmt.Fprintf(b, `<polyline points="%s" fill="none" stroke="%s" stroke-width="1.2"/>`, sb.String(), color)
+}
+
+func buildSnoringSVG(title string, points []timePoint, start, end int64, loc *time.Location) string {
+	if end <= start {
+		return emptyChartSVG(title)
+	}
+	span := float64(end - start)
+	innerW := float64(chartW - 2*chartMarginX)
+	innerH := float64(chartH - chartMarginTop - chartMarginBot)
+	yMax := 60.0
+	for _, p := range points {
+		if p.v > yMax {
+			yMax = p.v
+		}
+	}
+	xPos := func(t int64) float64 {
+		return float64(chartMarginX) + (float64(t-start)/span)*innerW
+	}
+	yPos := func(v float64) float64 {
+		return float64(chartMarginTop) + (1-v/yMax)*innerH
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, `<svg viewBox="0 0 %d %d" class="sleepviz">`, chartW, chartH)
+	fmt.Fprintf(&b, `<text x="8" y="14" font-size="11" fill="#555">%s</text>`, template.HTMLEscapeString(title))
+	for _, p := range points {
+		if p.v <= 0 || p.t < start || p.t > end {
+			continue
+		}
+		x := xPos(p.t)
+		yTop := yPos(p.v)
+		yBot := yPos(0)
+		fmt.Fprintf(&b, `<rect x="%.1f" y="%.1f" width="1.5" height="%.1f" fill="#5d4037"/>`, x-0.75, yTop, yBot-yTop)
+	}
+	writeTimeAxis(&b, start, end, loc, chartH-chartMarginBot+12)
+	b.WriteString(`</svg>`)
+	return b.String()
+}
+
+func emptyChartSVG(title string) string {
+	return fmt.Sprintf(`<svg viewBox="0 0 %d %d" class="sleepviz"><text x="8" y="14" font-size="11" fill="#555">%s</text><text x="%d" y="%d" font-size="10" fill="#aaa" text-anchor="middle">no samples in window</text></svg>`,
+		chartW, chartH, template.HTMLEscapeString(title), chartW/2, chartH/2)
+}

--- a/pkg/withoutings/port/sleep_session.go
+++ b/pkg/withoutings/port/sleep_session.go
@@ -71,37 +71,41 @@ func buildSleepSessionView(
 	startdate int64,
 ) (templates.SleepSessionView, error) {
 	view := templates.SleepSessionView{Startdate: startdate}
-
-	summaryRows, err := repo.GetNotificationDataByAccountUUIDAndService(ctx, accountUUID, subscription.NotificationDataServiceSleepv2Getsummary)
-	if err != nil {
-		return view, fmt.Errorf("get summary rows: %w", err)
-	}
-
 	log := logging.MustGetLoggerFromContext(ctx)
+
+	// Single indexed lookup against the JSONB GIN index — pulls the one row
+	// (if any) whose body.series array contains an entry with this startdate.
+	// Avoids loading every Sleep v2 - Getsummary blob for the user.
+	summaryRow, err := repo.GetNotificationDataByAccountAndServiceAndSeriesStartdate(
+		ctx, accountUUID, subscription.NotificationDataServiceSleepv2Getsummary, startdate,
+	)
+	if err != nil {
+		return view, fmt.Errorf("get summary row: %w", err)
+	}
+	if summaryRow == nil {
+		return view, nil
+	}
 
 	var summary withings.SleepGetsummaryEntry
 	var summaryFound bool
-	for _, row := range summaryRows {
-		var resp withings.SleepGetsummaryResponse
-		if err := json.Unmarshal(row.Data(), &resp); err != nil {
-			log.WithError(err).
-				WithField("event", "warn.SleepSession.summary_unmarshal_failed").
-				WithField("notification_data_uuid", row.UUID()).
-				Warn()
-			continue
-		}
-		for _, entry := range resp.Body.Series {
-			if int64(entry.Startdate) == startdate {
-				summary = entry
-				summaryFound = true
-				break
-			}
-		}
-		if summaryFound {
+	var resp withings.SleepGetsummaryResponse
+	if err := json.Unmarshal(summaryRow.Data(), &resp); err != nil {
+		log.WithError(err).
+			WithField("event", "warn.SleepSession.summary_unmarshal_failed").
+			WithField("notification_data_uuid", summaryRow.UUID()).
+			Warn()
+		return view, nil
+	}
+	for _, entry := range resp.Body.Series {
+		if int64(entry.Startdate) == startdate {
+			summary = entry
+			summaryFound = true
 			break
 		}
 	}
 	if !summaryFound {
+		// JSONB containment matched but the Go-side scan didn't — would only
+		// happen if the index says yes but the row's content disagrees.
 		return view, nil
 	}
 	view.Found = true

--- a/pkg/withoutings/port/sleep_session.go
+++ b/pkg/withoutings/port/sleep_session.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"math"
 	"net/http"
 	"sort"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/roessland/withoutings/pkg/logging"
+	"github.com/roessland/withoutings/pkg/web/templates"
 	"github.com/roessland/withoutings/pkg/withoutings/app"
 	"github.com/roessland/withoutings/pkg/withoutings/domain/account"
 	"github.com/roessland/withoutings/pkg/withoutings/domain/subscription"
@@ -67,19 +69,25 @@ func buildSleepSessionView(
 	repo subscription.Repo,
 	accountUUID uuid.UUID,
 	startdate int64,
-) (SleepSessionView, error) {
-	view := SleepSessionView{Startdate: startdate}
+) (templates.SleepSessionView, error) {
+	view := templates.SleepSessionView{Startdate: startdate}
 
 	summaryRows, err := repo.GetNotificationDataByAccountUUIDAndService(ctx, accountUUID, subscription.NotificationDataServiceSleepv2Getsummary)
 	if err != nil {
 		return view, fmt.Errorf("get summary rows: %w", err)
 	}
 
+	log := logging.MustGetLoggerFromContext(ctx)
+
 	var summary withings.SleepGetsummaryEntry
 	var summaryFound bool
 	for _, row := range summaryRows {
 		var resp withings.SleepGetsummaryResponse
 		if err := json.Unmarshal(row.Data(), &resp); err != nil {
+			log.WithError(err).
+				WithField("event", "warn.SleepSession.summary_unmarshal_failed").
+				WithField("notification_data_uuid", row.UUID()).
+				Warn()
 			continue
 		}
 		for _, entry := range resp.Body.Series {
@@ -97,7 +105,7 @@ func buildSleepSessionView(
 		return view, nil
 	}
 	view.Found = true
-	view.populateSummary(summary)
+	populateSummary(ctx, &view, summary)
 
 	// Pull all Sleep v2 - Get rows for the account; segments overlapping the
 	// session window contribute to the charts. Withings webhooks can deliver
@@ -114,6 +122,10 @@ func buildSleepSessionView(
 	for _, row := range getRows {
 		var resp withings.SleepGetResponse
 		if err := json.Unmarshal(row.Data(), &resp); err != nil {
+			log.WithError(err).
+				WithField("event", "warn.SleepSession.get_unmarshal_failed").
+				WithField("notification_data_uuid", row.UUID()).
+				Warn()
 			continue
 		}
 		for _, seg := range resp.Body.Series {
@@ -132,52 +144,15 @@ func buildSleepSessionView(
 		return segments[i].Startdate < segments[j].Startdate
 	})
 
-	view.buildCharts(segments, sessionStart, sessionEnd, summary.Timezone)
+	buildCharts(ctx, &view, segments, sessionStart, sessionEnd, summary.Timezone)
 	return view, nil
 }
 
-// SleepSessionView is the render-ready struct for the sleep detail template.
-type SleepSessionView struct {
-	Found     bool
-	Startdate int64
-
-	Date          string
-	Timezone      string
-	StartLocal    string
-	EndLocal      string
-	DurationStr   string
-	SleepScore    int
-	Efficiency    int    // 0–100
-	Light         string // "2h 21m"
-	Deep          string
-	REM           string
-	Awake         string
-	HRMin         int
-	HRAvg         int
-	HRMax         int
-	RRMin         int
-	RRAvg         int
-	RRMax         int
-	BreathingDist int
-	Snoring       string
-	SnoringCount  int
-	AHI           float64
-
-	Hypnogram template.HTML
-	HRChart   template.HTML
-	RRChart   template.HTML
-	HRVChart  template.HTML
-	Snoring01 template.HTML
-}
-
-func (v *SleepSessionView) populateSummary(s withings.SleepGetsummaryEntry) {
+func populateSummary(ctx context.Context, v *templates.SleepSessionView, s withings.SleepGetsummaryEntry) {
 	v.Date = s.Date
 	v.Timezone = s.Timezone
 
-	loc, err := time.LoadLocation(s.Timezone)
-	if err != nil {
-		loc = time.UTC
-	}
+	loc := loadLocationOrUTC(ctx, s.Timezone)
 	startT := time.Unix(int64(s.Startdate), 0).In(loc)
 	endT := time.Unix(int64(s.Enddate), 0).In(loc)
 	v.StartLocal = startT.Format("15:04")
@@ -230,11 +205,8 @@ const (
 )
 
 // buildCharts assembles the inline SVGs from the session segments.
-func (v *SleepSessionView) buildCharts(segments []withings.SleepGetEntry, sessionStart, sessionEnd int64, tz string) {
-	loc, err := time.LoadLocation(tz)
-	if err != nil {
-		loc = time.UTC
-	}
+func buildCharts(ctx context.Context, v *templates.SleepSessionView, segments []withings.SleepGetEntry, sessionStart, sessionEnd int64, tz string) {
+	loc := loadLocationOrUTC(ctx, tz)
 
 	var hr, rr, sdnn, rmssd, snoring []timePoint
 	for _, seg := range segments {
@@ -254,7 +226,23 @@ func (v *SleepSessionView) buildCharts(segments []withings.SleepGetEntry, sessio
 	v.HRChart = template.HTML(buildLineChartSVG("Heart rate (bpm)", hr, sessionStart, sessionEnd, loc, "#e91e63"))
 	v.RRChart = template.HTML(buildLineChartSVG("Respiratory rate (rpm)", rr, sessionStart, sessionEnd, loc, "#3f51b5"))
 	v.HRVChart = template.HTML(buildDualLineChartSVG("HRV (sdnn_1, rmssd)", sdnn, rmssd, sessionStart, sessionEnd, loc, "#009688", "#ff9800"))
-	v.Snoring01 = template.HTML(buildSnoringSVG("Snoring (s/min)", snoring, sessionStart, sessionEnd, loc))
+	v.SnoringChart = template.HTML(buildSnoringSVG("Snoring (s/min)", snoring, sessionStart, sessionEnd, loc))
+}
+
+// loadLocationOrUTC resolves a Withings timezone name with a UTC fallback,
+// emitting one warn-level log per failure so distroless / missing-tzdata
+// regressions and bad summary payloads aren't silently invisible.
+func loadLocationOrUTC(ctx context.Context, tz string) *time.Location {
+	loc, err := time.LoadLocation(tz)
+	if err == nil {
+		return loc
+	}
+	logging.MustGetLoggerFromContext(ctx).
+		WithError(err).
+		WithField("event", "warn.SleepSession.load_location_failed").
+		WithField("tz", tz).
+		Warn()
+	return time.UTC
 }
 
 func decodeSamples(raw []byte) []timePoint {
@@ -267,6 +255,13 @@ func decodeSamples(raw []byte) []timePoint {
 	}
 	out := make([]timePoint, 0, len(m))
 	for k, val := range m {
+		// Drop NaN/Inf early. Otherwise yMin/yMax seeding in the line-chart
+		// builder seeds from a non-finite value (NaN comparisons are always
+		// false), every projected coordinate is NaN, and the polyline renders
+		// as `NaN,NaN ...` — invisible and indistinguishable from no data.
+		if math.IsNaN(val) || math.IsInf(val, 0) {
+			continue
+		}
 		ts, err := strconv.ParseInt(k, 10, 64)
 		if err != nil {
 			continue
@@ -280,22 +275,24 @@ func sortPoints(p []timePoint) {
 	sort.Slice(p, func(i, j int) bool { return p[i].t < p[j].t })
 }
 
-// stateColors maps Withings sleep states to display colors.
-//
-//	0 = awake, 1 = light, 2 = deep, 3 = REM
-var stateColors = map[int]string{
-	0: "#bdbdbd",
-	1: "#90caf9",
-	2: "#1565c0",
-	3: "#ab47bc",
+// SleepStateInfo is the display metadata for a Withings sleep state.
+// Exposed so tests can assert against the same source of truth the SVG uses.
+type SleepStateInfo struct {
+	Color string
+	Label string
 }
 
-var stateLabels = map[int]string{
-	0: "Awake",
-	1: "Light",
-	2: "Deep",
-	3: "REM",
+// SleepStateInfoByState maps Withings sleep states (0=awake, 1=light, 2=deep,
+// 3=REM) to display metadata. States 4-6 (deprecated/manual per Withings docs)
+// fall through to a neutral fallback in buildHypnogramSVG.
+var SleepStateInfoByState = map[int]SleepStateInfo{
+	0: {Color: "#bdbdbd", Label: "Awake"},
+	1: {Color: "#90caf9", Label: "Light"},
+	2: {Color: "#1565c0", Label: "Deep"},
+	3: {Color: "#ab47bc", Label: "REM"},
 }
+
+const unknownStateColor = "#cccccc"
 
 func buildHypnogramSVG(segments []withings.SleepGetEntry, start, end int64, loc *time.Location) string {
 	if end <= start {
@@ -319,9 +316,12 @@ func buildHypnogramSVG(segments []withings.SleepGetEntry, start, end int64, loc 
 	fmt.Fprintf(&b, `<svg viewBox="0 0 %d %d" class="sleepviz">`, chartW, hypnoH)
 	fmt.Fprintf(&b, `<text x="8" y="14" font-size="11" fill="#555">Hypnogram</text>`)
 	for _, seg := range segments {
-		color, ok := stateColors[seg.State]
-		if !ok {
-			color = "#cccccc"
+		info, known := SleepStateInfoByState[seg.State]
+		color := info.Color
+		label := info.Label
+		if !known {
+			color = unknownStateColor
+			label = fmt.Sprintf("State %d", seg.State)
 		}
 		segStart := seg.Startdate
 		if segStart < start {
@@ -338,7 +338,7 @@ func buildHypnogramSVG(segments []withings.SleepGetEntry, start, end int64, loc 
 		x1 := x(segEnd)
 		fmt.Fprintf(&b, `<rect x="%.1f" y="%d" width="%.1f" height="%d" fill="%s"><title>%s %s–%s</title></rect>`,
 			x0, bandTop, x1-x0, bandBot-bandTop, color,
-			stateLabels[seg.State],
+			label,
 			time.Unix(segStart, 0).In(loc).Format("15:04"),
 			time.Unix(segEnd, 0).In(loc).Format("15:04"),
 		)
@@ -352,8 +352,9 @@ func buildHypnogramSVG(segments []withings.SleepGetEntry, start, end int64, loc 
 func writeLegend(b *strings.Builder, w int) {
 	x := w - 240
 	for i := 0; i < 4; i++ {
-		fmt.Fprintf(b, `<rect x="%d" y="2" width="10" height="10" fill="%s"/>`, x, stateColors[i])
-		fmt.Fprintf(b, `<text x="%d" y="11" font-size="10" fill="#444">%s</text>`, x+13, stateLabels[i])
+		info := SleepStateInfoByState[i]
+		fmt.Fprintf(b, `<rect x="%d" y="2" width="10" height="10" fill="%s"/>`, x, info.Color)
+		fmt.Fprintf(b, `<text x="%d" y="11" font-size="10" fill="#444">%s</text>`, x+13, info.Label)
 		x += 60
 	}
 }
@@ -364,40 +365,73 @@ func writeTimeAxis(b *strings.Builder, start, end int64, loc *time.Location, y i
 	}
 	span := float64(end - start)
 	innerW := float64(chartW - 2*chartMarginX)
-	startT := time.Unix(start, 0).In(loc).Truncate(time.Hour).Add(time.Hour)
+	// Compute the next local-hour boundary explicitly via time.Date so the
+	// axis lands on wall-clock hours in fractional-offset zones (e.g.
+	// Asia/Kolkata +05:30) and during DST transitions.
+	startLocal := time.Unix(start, 0).In(loc)
+	t := time.Date(startLocal.Year(), startLocal.Month(), startLocal.Day(), startLocal.Hour()+1, 0, 0, 0, loc)
 	endT := time.Unix(end, 0).In(loc)
-	for t := startT; !t.After(endT); t = t.Add(time.Hour) {
+	seenLabel := make(map[string]bool)
+	for ; !t.After(endT); t = t.Add(time.Hour) {
 		ts := t.Unix()
 		if ts <= start || ts >= end {
 			continue
 		}
+		// On DST fall-back the loop walks two unix-hours that share a wall
+		// clock label (e.g. 02:00 twice). Render the first only; the second
+		// would stack a duplicate tick on top of the first.
+		label := t.Format("15:04")
+		if seenLabel[label] {
+			continue
+		}
+		seenLabel[label] = true
 		x := float64(chartMarginX) + (float64(ts-start)/span)*innerW
 		fmt.Fprintf(b, `<line x1="%.1f" y1="%d" x2="%.1f" y2="%d" stroke="#ddd"/>`, x, chartMarginTop, x, y-12)
-		fmt.Fprintf(b, `<text x="%.1f" y="%d" font-size="10" text-anchor="middle" fill="#666">%s</text>`, x, y, t.Format("15:04"))
+		fmt.Fprintf(b, `<text x="%.1f" y="%d" font-size="10" text-anchor="middle" fill="#666">%s</text>`, x, y, label)
 	}
+}
+
+type lineSeries struct {
+	points []timePoint
+	color  string
 }
 
 func buildLineChartSVG(title string, points []timePoint, start, end int64, loc *time.Location, color string) string {
-	return buildDualLineChartSVG(title, points, nil, start, end, loc, color, "")
+	return buildLineChartsSVG(title, start, end, loc, lineSeries{points: points, color: color})
 }
 
 func buildDualLineChartSVG(title string, a, b []timePoint, start, end int64, loc *time.Location, colorA, colorB string) string {
+	return buildLineChartsSVG(title, start, end, loc,
+		lineSeries{points: a, color: colorA},
+		lineSeries{points: b, color: colorB},
+	)
+}
+
+func buildLineChartsSVG(title string, start, end int64, loc *time.Location, series ...lineSeries) string {
 	if end <= start {
 		return ""
 	}
-	all := make([]timePoint, 0, len(a)+len(b))
-	all = append(all, a...)
-	all = append(all, b...)
-	if len(all) == 0 {
+	totalPoints := 0
+	for _, s := range series {
+		totalPoints += len(s.points)
+	}
+	if totalPoints == 0 {
 		return emptyChartSVG(title)
 	}
-	yMin, yMax := all[0].v, all[0].v
-	for _, p := range all {
-		if p.v < yMin {
-			yMin = p.v
-		}
-		if p.v > yMax {
-			yMax = p.v
+	var yMin, yMax float64
+	seeded := false
+	for _, s := range series {
+		for _, p := range s.points {
+			if !seeded {
+				yMin, yMax, seeded = p.v, p.v, true
+				continue
+			}
+			if p.v < yMin {
+				yMin = p.v
+			}
+			if p.v > yMax {
+				yMax = p.v
+			}
 		}
 	}
 	if yMax == yMin {
@@ -418,9 +452,8 @@ func buildDualLineChartSVG(title string, a, b []timePoint, start, end int64, loc
 	fmt.Fprintf(&sb, `<text x="8" y="14" font-size="11" fill="#555">%s</text>`, template.HTMLEscapeString(title))
 	fmt.Fprintf(&sb, `<text x="%d" y="%.1f" font-size="10" fill="#888" text-anchor="end">%.0f</text>`, chartMarginX-4, yPos(yMax)+3, yMax)
 	fmt.Fprintf(&sb, `<text x="%d" y="%.1f" font-size="10" fill="#888" text-anchor="end">%.0f</text>`, chartMarginX-4, yPos(yMin)+3, yMin)
-	writePolyline(&sb, a, xPos, yPos, colorA, start, end)
-	if colorB != "" {
-		writePolyline(&sb, b, xPos, yPos, colorB, start, end)
+	for _, s := range series {
+		writePolyline(&sb, s.points, xPos, yPos, s.color, start, end)
 	}
 	writeTimeAxis(&sb, start, end, loc, chartH-chartMarginBot+12)
 	sb.WriteString(`</svg>`)
@@ -432,19 +465,28 @@ func writePolyline(b *strings.Builder, points []timePoint, xPos func(int64) floa
 		return
 	}
 	var sb strings.Builder
-	first := true
+	type xy struct{ x, y float64 }
+	var inWindow []xy
 	for _, p := range points {
 		if p.t < start || p.t > end {
 			continue
 		}
-		if !first {
+		inWindow = append(inWindow, xy{x: xPos(p.t), y: yPos(p.v)})
+	}
+	if len(inWindow) == 0 {
+		return
+	}
+	if len(inWindow) == 1 {
+		// A single sample renders a polyline with one vertex, which draws
+		// nothing. Emit a small circle so the data point is at least visible.
+		fmt.Fprintf(b, `<circle cx="%.1f" cy="%.1f" r="1.5" fill="%s"/>`, inWindow[0].x, inWindow[0].y, color)
+		return
+	}
+	for i, p := range inWindow {
+		if i > 0 {
 			sb.WriteByte(' ')
 		}
-		first = false
-		fmt.Fprintf(&sb, "%.1f,%.1f", xPos(p.t), yPos(p.v))
-	}
-	if first {
-		return
+		fmt.Fprintf(&sb, "%.1f,%.1f", p.x, p.y)
 	}
 	fmt.Fprintf(b, `<polyline points="%s" fill="none" stroke="%s" stroke-width="1.2"/>`, sb.String(), color)
 }

--- a/pkg/withoutings/port/sleep_session_test.go
+++ b/pkg/withoutings/port/sleep_session_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/roessland/withoutings/pkg/integrationtest"
 	"github.com/roessland/withoutings/pkg/withoutings/domain/account"
 	"github.com/roessland/withoutings/pkg/withoutings/domain/subscription"
+	"github.com/roessland/withoutings/pkg/withoutings/port"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -156,10 +158,18 @@ func TestSleepSessionPage(t *testing.T) {
 		assert.Contains(t, body, "Heart rate (bpm)")
 		assert.Contains(t, body, "Respiratory rate (rpm)")
 		assert.Contains(t, body, "HRV (sdnn_1, rmssd)")
-		// hypnogram should reference each state color used in the fixture
-		assert.Contains(t, body, stateColorAssert(1)) // light
-		assert.Contains(t, body, stateColorAssert(2)) // deep
-		assert.Contains(t, body, stateColorAssert(3)) // rem
+		// Hypnogram must include the same color the SVG renders for each
+		// state present in the fixture. Sourcing from the production map
+		// instead of duplicating hex codes keeps tests coupled to one map.
+		for _, state := range []int{1, 2, 3} {
+			assert.Contains(t, body, port.SleepStateInfoByState[state].Color, "missing color for state %d", state)
+		}
+		// Charts must include polylines (multi-sample series), not just titles.
+		assert.Contains(t, body, "<polyline ")
+		// y-axis bounds for HR fixture are 50..72 (from summary), but the
+		// chart bounds come from the Sleep v2 - Get samples (50..60), so
+		// assert the rendered bounds are present.
+		assert.Contains(t, body, "stroke=\"#e91e63\"") // HR series color
 	})
 
 	t.Run("missing session shows friendly empty state", func(t *testing.T) {
@@ -170,7 +180,50 @@ func TestSleepSessionPage(t *testing.T) {
 		resp, body := doSessionReq(1700099999)
 		assert.Equal(t, 200, resp.Code)
 		assert.Contains(t, body, "No stored data for this session")
+		// Empty state must not render any chart chrome — it's how we verify
+		// the handler returned `Found: false` rather than rendering with
+		// missing-data noise.
 		assert.NotContains(t, body, "Hypnogram")
+		assert.NotContains(t, body, "<polyline")
+		assert.NotContains(t, body, "<svg")
+	})
+
+	t.Run("unauthenticated request gets 401", func(t *testing.T) {
+		beforeEach(t)
+		// Request without an account in context — exercises the guard at the
+		// top of the handler, which previously had no test.
+		req := httptest.NewRequest(http.MethodGet, "/sleepsessions/1700000000", nil)
+		req = req.WithContext(it.Ctx)
+		resp, body := it.DoRequest(req)
+		assert.Equal(t, http.StatusUnauthorized, resp.Code)
+		assert.Contains(t, body, "must be logged in")
+	})
+
+	t.Run("non-UTC fixture renders with local hour-tick labels", func(t *testing.T) {
+		// 2026-03-29 spans the spring-forward transition in Europe/Oslo
+		// (02:00 -> 03:00 CET -> CEST). The hour-tick loop must skip the
+		// jumped-over hour, not stack labels. We assert at minimum that the
+		// rendered axis carries one local 02:00 label or one local 03:00
+		// label, never both — that's the regression signal.
+		beforeEach(t)
+
+		// 2026-03-29 00:00 Europe/Oslo = 1774738800 (CET, +01:00).
+		// 8h sleep ending 2026-03-29 08:00 local = 1774764000.
+		const summary = `{"status":0,"body":{"series":[{"id":1,"timezone":"Europe/Oslo","model":32,"model_id":63,"startdate":1774738800,"enddate":1774764000,"date":"2026-03-29","data":{"total_sleep_time":25200,"sleep_score":80,"sleep_efficiency":0.9,"hr_average":58,"rr_average":16}}]}}`
+		const get = `{"status":0,"body":{"series":[{"startdate":1774738800,"enddate":1774764000,"state":1,"hr":{"1774738800":58,"1774762800":60},"rr":{"1774738800":16,"1774762800":17}}]}}`
+
+		insertSession(t, it.Ctx, summary, get)
+
+		resp, body := doSessionReq(1774738800)
+		assert.Equal(t, 200, resp.Code)
+		assert.Contains(t, body, "Sleep session — 2026-03-29")
+		assert.Contains(t, body, "Europe/Oslo")
+		// Spring-forward skips 02:00 in Europe/Oslo; the spring-skipped label
+		// must not appear at all. The 03:00 label must be present (once).
+		assert.Equal(t, 0, countOccurrences(body, ">02:00<"), "02:00 must not be rendered during spring-forward")
+		assert.GreaterOrEqual(t, countOccurrences(body, ">03:00<"), 1, "03:00 must be rendered as a real wall-clock hour")
+		// Wall-clock 04:00 sanity check — appears in the morning hours of the night.
+		assert.GreaterOrEqual(t, countOccurrences(body, ">04:00<"), 1)
 	})
 
 	t.Run("rejects non-numeric startdate", func(t *testing.T) {
@@ -185,19 +238,4 @@ func TestSleepSessionPage(t *testing.T) {
 
 func ptrTime(t time.Time) *time.Time { return &t }
 
-// stateColorAssert returns the hex color used for a Withings sleep state in the
-// rendered SVG, mirroring the table in sleep_session.go (kept private). If the
-// production map changes, this helper must move with it.
-func stateColorAssert(state int) string {
-	switch state {
-	case 0:
-		return "#bdbdbd"
-	case 1:
-		return "#90caf9"
-	case 2:
-		return "#1565c0"
-	case 3:
-		return "#ab47bc"
-	}
-	return ""
-}
+func countOccurrences(haystack, needle string) int { return strings.Count(haystack, needle) }

--- a/pkg/withoutings/port/sleep_session_test.go
+++ b/pkg/withoutings/port/sleep_session_test.go
@@ -172,6 +172,31 @@ func TestSleepSessionPage(t *testing.T) {
 		assert.Contains(t, body, "stroke=\"#e91e63\"") // HR series color
 	})
 
+	t.Run("with multiple stored summaries picks the matching startdate", func(t *testing.T) {
+		// Insert three different nights worth of stored Getsummary data; the
+		// JSONB-indexed lookup must pick the right one and ignore the others.
+		// This is the regression signal if someone removes the @> filter and
+		// the query falls back to fetching all rows.
+		beforeEach(t)
+
+		const otherSummary1 = `{"status":0,"body":{"series":[{"id":1,"timezone":"UTC","model":32,"model_id":63,"startdate":1600000000,"enddate":1600025200,"date":"2020-09-13","data":{"total_sleep_time":25200,"sleep_score":50,"sleep_efficiency":0.8,"hr_average":99,"rr_average":99}}]}}`
+		const otherSummary2 = `{"status":0,"body":{"series":[{"id":2,"timezone":"UTC","model":32,"model_id":63,"startdate":1750000000,"enddate":1750025200,"date":"2025-06-15","data":{"total_sleep_time":25200,"sleep_score":60,"sleep_efficiency":0.85,"hr_average":88,"rr_average":88}}]}}`
+
+		insertSession(t, it.Ctx, otherSummary1, sleepGetFixture)
+		insertSession(t, it.Ctx, sleepSummaryFixture, sleepGetFixture)
+		insertSession(t, it.Ctx, otherSummary2, sleepGetFixture)
+
+		resp, body := doSessionReq(1700000000)
+		assert.Equal(t, 200, resp.Code)
+		assert.Contains(t, body, "Sleep session — 2023-11-14")
+		// Decoy summary dates must not appear — the JSONB filter must have
+		// excluded those rows. (Score / HR overlap with the SVG axis labels
+		// of the matching session, so date is the uniquely-identifying field
+		// to assert on here.)
+		assert.NotContains(t, body, "2020-09-13")
+		assert.NotContains(t, body, "2025-06-15")
+	})
+
 	t.Run("missing session shows friendly empty state", func(t *testing.T) {
 		beforeEach(t)
 		// Insert a session, then ask for a different startdate.

--- a/pkg/withoutings/port/sleep_session_test.go
+++ b/pkg/withoutings/port/sleep_session_test.go
@@ -1,0 +1,203 @@
+package port_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/roessland/withoutings/pkg/integrationtest"
+	"github.com/roessland/withoutings/pkg/withoutings/domain/account"
+	"github.com/roessland/withoutings/pkg/withoutings/domain/subscription"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// One coherent night fixture: Getsummary entry references the same window that
+// the Get segments cover. We construct minimal payloads inline so the assertions
+// below check the parser and chart wiring, not Withings JSON nuances.
+const sleepSummaryFixture = `{
+  "status": 0,
+  "body": {
+    "series": [{
+      "id": 1,
+      "timezone": "UTC",
+      "model": 32,
+      "model_id": 63,
+      "startdate": 1700000000,
+      "enddate": 1700025200,
+      "date": "2023-11-14",
+      "data": {
+        "total_sleep_time": 25200,
+        "total_timeinbed": 25200,
+        "lightsleepduration": 14400,
+        "deepsleepduration": 7200,
+        "remsleepduration": 3600,
+        "sleep_efficiency": 0.92,
+        "sleep_score": 87,
+        "wakeupduration": 600,
+        "wakeupcount": 1,
+        "hr_average": 58,
+        "hr_min": 50,
+        "hr_max": 72,
+        "rr_average": 16,
+        "rr_min": 12,
+        "rr_max": 22,
+        "snoring": 120,
+        "snoringepisodecount": 2,
+        "apnea_hypopnea_index": 1.5,
+        "breathing_disturbances_intensity": 3
+      }
+    }]
+  }
+}`
+
+const sleepGetFixture = `{
+  "status": 0,
+  "body": {
+    "series": [
+      {"startdate": 1700000000, "enddate": 1700003600, "state": 1, "model": "Aura", "model_id": 63,
+       "hr": {"1700000000": 60, "1700001800": 58},
+       "rr": {"1700000000": 17, "1700001800": 16},
+       "snoring": {"1700000000": 0, "1700001800": 30},
+       "sdnn_1": {"1700000000": 40, "1700001800": 42},
+       "rmssd": {"1700000000": 35, "1700001800": 36}},
+      {"startdate": 1700003600, "enddate": 1700014400, "state": 2, "model": "Aura", "model_id": 63,
+       "hr": {"1700003600": 52, "1700010000": 50},
+       "rr": {"1700003600": 14, "1700010000": 13},
+       "snoring": {"1700003600": 0},
+       "sdnn_1": {"1700003600": 55},
+       "rmssd": {"1700003600": 50}},
+      {"startdate": 1700014400, "enddate": 1700020000, "state": 3, "model": "Aura", "model_id": 63,
+       "hr": {"1700014400": 65, "1700017000": 70},
+       "rr": {"1700014400": 18, "1700017000": 19},
+       "snoring": {"1700014400": 0},
+       "sdnn_1": {"1700014400": 48},
+       "rmssd": {"1700014400": 55}},
+      {"startdate": 1700020000, "enddate": 1700025200, "state": 0, "model": "Aura", "model_id": 63,
+       "hr": {"1700020000": 70},
+       "rr": {"1700020000": 20},
+       "snoring": {"1700020000": 0},
+       "sdnn_1": {"1700020000": 30},
+       "rmssd": {"1700020000": 25}}
+    ]
+  }
+}`
+
+func TestSleepSessionPage(t *testing.T) {
+	it := integrationtest.WithFreshDatabase(t)
+
+	var acc *account.Account
+
+	doSessionReq := func(startdate int64) (*httptest.ResponseRecorder, string) {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/sleepsessions/%d", startdate), nil)
+		req = req.WithContext(account.AddToContext(it.Ctx, acc))
+		return it.DoRequest(req)
+	}
+
+	beforeEach := func(t *testing.T) {
+		it.ResetMocks(t)
+		acc = it.MakeNewAccount(t)
+	}
+
+	insertSession := func(t *testing.T, ctx context.Context, summaryJSON, getJSON string) uuid.UUID {
+		t.Helper()
+		notif := subscription.MustNewNotification(subscription.NewNotificationParams{
+			NotificationUUID:    uuid.New(),
+			AccountUUID:         acc.UUID(),
+			ReceivedAt:          time.Now(),
+			Params:              "userid=1&startdate=1700000000&enddate=1700025200&appli=44",
+			DataStatus:          subscription.NotificationDataStatusFetched,
+			FetchedAt:           ptrTime(time.Now()),
+			RawNotificationUUID: uuid.New(),
+			Source:              "test",
+		})
+		require.NoError(t, it.App.SubscriptionRepo.CreateNotification(ctx, notif))
+		require.NoError(t, it.App.SubscriptionRepo.StoreNotificationData(ctx, subscription.MustNewNotificationData(subscription.NewNotificationDataParams{
+			NotificationDataUUID: uuid.New(),
+			NotificationUUID:     notif.UUID(),
+			AccountUUID:          acc.UUID(),
+			Service:              subscription.NotificationDataServiceSleepv2Getsummary,
+			Data:                 []byte(summaryJSON),
+			FetchedAt:            time.Now(),
+		})))
+		require.NoError(t, it.App.SubscriptionRepo.StoreNotificationData(ctx, subscription.MustNewNotificationData(subscription.NewNotificationDataParams{
+			NotificationDataUUID: uuid.New(),
+			NotificationUUID:     notif.UUID(),
+			AccountUUID:          acc.UUID(),
+			Service:              subscription.NotificationDataServiceSleepv2Get,
+			Data:                 []byte(getJSON),
+			FetchedAt:            time.Now(),
+		})))
+		return notif.UUID()
+	}
+
+	t.Run("renders summary stats and inline SVG charts", func(t *testing.T) {
+		beforeEach(t)
+		insertSession(t, it.Ctx, sleepSummaryFixture, sleepGetFixture)
+
+		resp, body := doSessionReq(1700000000)
+		assert.Equal(t, 200, resp.Code)
+
+		// Summary card values
+		assert.Contains(t, body, "Sleep session — 2023-11-14")
+		assert.Contains(t, body, ">87<")    // sleep score
+		assert.Contains(t, body, "7h 00m")  // total sleep
+		assert.Contains(t, body, "92%")     // efficiency
+		assert.Contains(t, body, ">58 bpm") // hr average
+		assert.Contains(t, body, ">16 rpm") // rr average
+		assert.Contains(t, body, "1.5")     // AHI
+
+		// Inline charts
+		assert.Contains(t, body, "Hypnogram")
+		assert.Contains(t, body, "Heart rate (bpm)")
+		assert.Contains(t, body, "Respiratory rate (rpm)")
+		assert.Contains(t, body, "HRV (sdnn_1, rmssd)")
+		// hypnogram should reference each state color used in the fixture
+		assert.Contains(t, body, stateColorAssert(1)) // light
+		assert.Contains(t, body, stateColorAssert(2)) // deep
+		assert.Contains(t, body, stateColorAssert(3)) // rem
+	})
+
+	t.Run("missing session shows friendly empty state", func(t *testing.T) {
+		beforeEach(t)
+		// Insert a session, then ask for a different startdate.
+		insertSession(t, it.Ctx, sleepSummaryFixture, sleepGetFixture)
+
+		resp, body := doSessionReq(1700099999)
+		assert.Equal(t, 200, resp.Code)
+		assert.Contains(t, body, "No stored data for this session")
+		assert.NotContains(t, body, "Hypnogram")
+	})
+
+	t.Run("rejects non-numeric startdate", func(t *testing.T) {
+		beforeEach(t)
+		// gorilla/mux returns 404 for path that doesn't match the regex.
+		req := httptest.NewRequest(http.MethodGet, "/sleepsessions/notanumber", nil)
+		req = req.WithContext(account.AddToContext(it.Ctx, acc))
+		resp, _ := it.DoRequest(req)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
+	})
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+// stateColorAssert returns the hex color used for a Withings sleep state in the
+// rendered SVG, mirroring the table in sleep_session.go (kept private). If the
+// production map changes, this helper must move with it.
+func stateColorAssert(state int) string {
+	switch state {
+	case 0:
+		return "#bdbdbd"
+	case 1:
+		return "#90caf9"
+	case 2:
+		return "#1565c0"
+	case 3:
+		return "#ab47bc"
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- New page \`GET /sleepsessions/{startdate}\` that visualises a single sleep session.
- The 30-day sleep page (\`/sleepsummaries\`) now links each row's date cell to the detail page (\`startdate\` from the matching \`Sleep v2 - Getsummary\` series).
- Data is read from \`notification_data\` rows that the appli=44 webhook handler already persists (no live Withings call from the detail page).
- Inline server-side SVG charts: hypnogram (state bands clipped to the session window), heart rate, respiratory rate, HRV (\`sdnn_1\` and \`rmssd\`), snoring intensity. No JS, no external assets.
- If we have no stored \`Sleep v2 - Getsummary\` entry matching the requested \`startdate\`, the page renders a friendly empty state instead of 404'ing — sessions captured before the user subscribed to appli=44 simply won't have data.
- New repo method \`GetNotificationDataByAccountUUIDAndService\` keeps the per-account scan to one query per service.

## Test plan
- [x] \`PGPORT=54329 go test ./pkg/withoutings/port/ -run TestSleepSessionPage -count=1\` (renders + missing-session + invalid-startdate)
- [x] \`PGPORT=54329 go test ./... -count=1\`
- [ ] Manual: log in, click a date on \`/sleepsummaries\`, confirm SVGs render in browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)