### PR TITLE
worker: own the publisher's close so handlers don't race

### DIFF
--- a/pkg/worker/publisher.go
+++ b/pkg/worker/publisher.go
@@ -1,0 +1,24 @@
+package worker
+
+import "github.com/ThreeDotsLabs/watermill/message"
+
+// noopClosePublisher delegates Publish to its inner publisher and makes Close
+// a no-op. Used to hand the same shared publisher to multiple watermill
+// handlers without each one independently closing it on shutdown.
+//
+// Watermill's router runs `defer h.publisher.Close()` per handler when the
+// handler exits (router.go ~625 in v1.3.x – v1.5.x). With one shared
+// publisher and N handlers, that's N concurrent Close calls on the same
+// underlying publisher, which races on watermill-sql's unsynchronised
+// `closed` flag and risks a double close-of-channel panic. Wrapping the
+// publisher per handler with a no-op Close means the worker's deferred
+// single Close is the only one that actually runs.
+type noopClosePublisher struct {
+	inner message.Publisher
+}
+
+func (p noopClosePublisher) Publish(topic string, msgs ...*message.Message) error {
+	return p.inner.Publish(topic, msgs...)
+}
+
+func (noopClosePublisher) Close() error { return nil }

--- a/pkg/worker/publisher_test.go
+++ b/pkg/worker/publisher_test.go
@@ -1,0 +1,42 @@
+package worker
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/stretchr/testify/assert"
+)
+
+// recordingPublisher counts Publish/Close so the wrapper test can verify
+// Publish delegates and Close is a no-op.
+type recordingPublisher struct {
+	publishes atomic.Int32
+	closes    atomic.Int32
+}
+
+func (p *recordingPublisher) Publish(string, ...*message.Message) error {
+	p.publishes.Add(1)
+	return nil
+}
+
+func (p *recordingPublisher) Close() error {
+	p.closes.Add(1)
+	return nil
+}
+
+func TestNoopClosePublisher_DelegatesPublishButNotClose(t *testing.T) {
+	inner := &recordingPublisher{}
+	wrapped := noopClosePublisher{inner: inner}
+
+	assert.NoError(t, wrapped.Publish("topic", message.NewMessage("1", nil)))
+	assert.Equal(t, int32(1), inner.publishes.Load(), "Publish must delegate")
+
+	// Watermill's per-handler shutdown calls Close on each handler's
+	// publisher. With many handlers sharing the inner publisher, the worker
+	// hands each a fresh wrapper; their Close calls must not propagate.
+	for i := 0; i < 10; i++ {
+		assert.NoError(t, wrapped.Close())
+	}
+	assert.Equal(t, int32(0), inner.closes.Load(), "Close must be a no-op")
+}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -38,6 +38,16 @@ func (wrk *Worker) Work(ctx context.Context) {
 
 	log.WithField("event", "info.worker.started").Info()
 
+	// The worker owns the publisher's lifecycle. Hand handlers a no-op-Close
+	// wrapper so watermill's per-handler `defer publisher.Close()` doesn't
+	// race the shared publisher; close once here when the router exits.
+	handlerPublisher := noopClosePublisher{inner: wrk.Publisher}
+	defer func() {
+		if err := wrk.Publisher.Close(); err != nil {
+			log.WithError(err).WithField("event", "error.worker.publisher.close.failed").Error()
+		}
+	}()
+
 	router, err := message.NewRouter(message.RouterConfig{}, wmLog)
 	if err != nil {
 		log.WithError(err).WithField("event", "panic.worker.NewRouter.failed").Error()
@@ -52,7 +62,7 @@ func (wrk *Worker) Work(ctx context.Context) {
 		topic.WithingsRawNotificationReceived,
 		wrk.Subscriber,
 		topic.WithingsNotificationReceived,
-		wrk.Publisher,
+		handlerPublisher,
 		func(msg *message.Message) ([]*message.Message, error) {
 			log = log.
 				WithField("handler_name", "process_raw_notification").
@@ -125,7 +135,7 @@ func (wrk *Worker) Work(ctx context.Context) {
 		topic.WithingsNotificationReceived,
 		wrk.Subscriber,
 		topic.WithingsNotificationDataFetched,
-		wrk.Publisher,
+		handlerPublisher,
 		func(msg *message.Message) ([]*message.Message, error) {
 			log = log.
 				WithField("handler_name", "fetch_notification_data").


### PR DESCRIPTION
## Summary
- Root cause: watermill's router runs \`defer h.publisher.Close()\` per handler when the handler exits (\`router.go ~625\` in v1.3.x – v1.5.x). Both worker handlers share \`wrk.Publisher\`, so on shutdown each handler goroutine independently invokes Close on the same publisher. \`watermill-sql\` \`Publisher.Close\` has an unsynchronised check-and-set on \`closed\` plus \`close(closeCh)\` — same shape from v3.0.1 through v4.1.3, not fixed upstream.
- Fix at the wiring boundary, not by making the inner publisher tolerate misuse:
  - New \`noopClosePublisher\` in \`pkg/worker/publisher.go\`: delegates \`Publish\`, makes \`Close\` a no-op.
  - Worker hands each handler a \`noopClosePublisher{inner: wrk.Publisher}\` and \`defer wrk.Publisher.Close()\` at the start of \`Work\`. Watermill's per-handler Close is now a NOP; the real Close runs exactly once when the worker is done.
- \`publishWg.Wait()\` semantics are preserved (the deferred real Close still drains in-flight Publishes), ownership is explicit (the worker owns the publisher's lifecycle, watermill is a borrower), and the race disappears because there's only ever one Close on the inner publisher.

## Test plan
- [x] \`go test -race ./pkg/worker/\` — \`noopClosePublisher\` delegates Publish, swallows Close (10 calls, inner.closes stays at 0).
- [x] \`PGPORT=54329 go test -race ./... -count=1\` — full suite under -race; the \`subscriptions_notifications_test.go\` race that fired in CI is gone.

## Notes
- A separate hygiene PR will follow to bump \`watermill\` v1.3.5 → v1.5.1 and \`watermill-sql\` v3.0.1 → v4.1.3. Verified neither upgrade fixes this race on its own — both newer versions ship the same Close shape — so the wiring fix lands first and the bumps are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)