### PR TITLE
sleep session: filter Sleep v2 - Get rows by window in SQL

### DIFF
--- a/pkg/db/subscription.sql
+++ b/pkg/db/subscription.sql
@@ -164,3 +164,23 @@ WHERE account_uuid = $1
   AND data -> 'body' -> 'series' @> jsonb_build_array(jsonb_build_object('startdate', sqlc.arg(startdate)::bigint))
 ORDER BY fetched_at DESC
 LIMIT 1;
+
+-- name: GetNotificationDataByAccountAndServiceAndOverlappingWindow :many
+-- Returns notification_data rows whose JSONB body.series array contains at
+-- least one segment overlapping [window_start, window_end]. Used by the
+-- sleep detail page to fetch only the Sleep v2 - Get rows that actually
+-- contribute to the requested session, rather than every stored Get blob
+-- (which is hundreds of KB per row when the user has months of history).
+-- The EXISTS keeps this a per-row check in Postgres so we never transfer
+-- (and Go never unmarshals) rows that can't contribute.
+SELECT *
+FROM notification_data
+WHERE account_uuid = $1
+  AND service = $2
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(data -> 'body' -> 'series') seg
+    WHERE (seg ->> 'startdate')::bigint < sqlc.arg(window_end)::bigint
+      AND (seg ->> 'enddate')::bigint > sqlc.arg(window_start)::bigint
+  )
+ORDER BY fetched_at DESC;

--- a/pkg/db/subscription.sql.go
+++ b/pkg/db/subscription.sql.go
@@ -212,6 +212,66 @@ func (q *Queries) GetNotificationByUUID(ctx context.Context, notificationUuid uu
 	return i, err
 }
 
+const getNotificationDataByAccountAndServiceAndOverlappingWindow = `-- name: GetNotificationDataByAccountAndServiceAndOverlappingWindow :many
+SELECT notification_data_uuid, account_uuid, notification_uuid, service, data, fetched_at
+FROM notification_data
+WHERE account_uuid = $1
+  AND service = $2
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(data -> 'body' -> 'series') seg
+    WHERE (seg ->> 'startdate')::bigint < $3::bigint
+      AND (seg ->> 'enddate')::bigint > $4::bigint
+  )
+ORDER BY fetched_at DESC
+`
+
+type GetNotificationDataByAccountAndServiceAndOverlappingWindowParams struct {
+	AccountUuid uuid.UUID
+	Service     string
+	WindowEnd   int64
+	WindowStart int64
+}
+
+// Returns notification_data rows whose JSONB body.series array contains at
+// least one segment overlapping [window_start, window_end]. Used by the
+// sleep detail page to fetch only the Sleep v2 - Get rows that actually
+// contribute to the requested session, rather than every stored Get blob
+// (which is hundreds of KB per row when the user has months of history).
+// The EXISTS keeps this a per-row check in Postgres so we never transfer
+// (and Go never unmarshals) rows that can't contribute.
+func (q *Queries) GetNotificationDataByAccountAndServiceAndOverlappingWindow(ctx context.Context, arg GetNotificationDataByAccountAndServiceAndOverlappingWindowParams) ([]NotificationDatum, error) {
+	rows, err := q.db.Query(ctx, getNotificationDataByAccountAndServiceAndOverlappingWindow,
+		arg.AccountUuid,
+		arg.Service,
+		arg.WindowEnd,
+		arg.WindowStart,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []NotificationDatum
+	for rows.Next() {
+		var i NotificationDatum
+		if err := rows.Scan(
+			&i.NotificationDataUuid,
+			&i.AccountUuid,
+			&i.NotificationUuid,
+			&i.Service,
+			&i.Data,
+			&i.FetchedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getNotificationDataByAccountAndServiceAndSeriesStartdate = `-- name: GetNotificationDataByAccountAndServiceAndSeriesStartdate :many
 SELECT notification_data_uuid, account_uuid, notification_uuid, service, data, fetched_at
 FROM notification_data

--- a/pkg/withoutings/adapter/subscription/subscription_pg_repo.go
+++ b/pkg/withoutings/adapter/subscription/subscription_pg_repo.go
@@ -482,6 +482,19 @@ func (r PgRepo) GetNotificationDataByAccountAndServiceAndSeriesStartdate(ctx con
 	return toDomainNotificationDatum(dbRows[0])
 }
 
+func (r PgRepo) GetNotificationDataByAccountAndServiceAndOverlappingWindow(ctx context.Context, accountUUID uuid.UUID, service subscription.NotificationDataService, windowStart, windowEnd int64) ([]*subscription.NotificationData, error) {
+	dbRows, err := r.queries.GetNotificationDataByAccountAndServiceAndOverlappingWindow(ctx, db.GetNotificationDataByAccountAndServiceAndOverlappingWindowParams{
+		AccountUuid: accountUUID,
+		Service:     string(service),
+		WindowStart: windowStart,
+		WindowEnd:   windowEnd,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return toDomainNotificationData(dbRows)
+}
+
 func toDomainNotificationDatum(dbNotificationData db.NotificationDatum) (*subscription.NotificationData, error) {
 	service, err := subscription.NewNotificationDataService(dbNotificationData.Service)
 	if err != nil {

--- a/pkg/withoutings/adapter/subscription/subscription_pg_repo_test.go
+++ b/pkg/withoutings/adapter/subscription/subscription_pg_repo_test.go
@@ -109,4 +109,49 @@ func TestSubscriptionPgRepo(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, notifications, 1)
 	})
+
+	t.Run("GetNotificationDataByAccountAndServiceAndOverlappingWindow returns only overlapping rows", func(t *testing.T) {
+		// Three Sleep v2 - Get rows: only the middle one's body.series
+		// overlaps the requested [3000, 4000] window. The other two are
+		// strictly before / strictly after and must be filtered in SQL.
+		insert := func(notifUUID uuid.UUID, body string) {
+			t.Helper()
+			notif := subscription.MustNewNotification(subscription.NewNotificationParams{
+				NotificationUUID:    notifUUID,
+				AccountUUID:         accountUUID,
+				ReceivedAt:          time.Now(),
+				Params:              "x",
+				DataStatus:          subscription.NotificationDataStatusFetched,
+				FetchedAt:           ptrTimeAdapter(time.Now()),
+				RawNotificationUUID: uuid.New(),
+				Source:              "test",
+			})
+			require.NoError(t, repo.CreateNotification(ctx, notif))
+			data := subscription.MustNewNotificationData(subscription.NewNotificationDataParams{
+				NotificationDataUUID: uuid.New(),
+				NotificationUUID:     notifUUID,
+				AccountUUID:          accountUUID,
+				Service:              subscription.NotificationDataServiceSleepv2Get,
+				Data:                 []byte(body),
+				FetchedAt:            time.Now(),
+			})
+			require.NoError(t, repo.StoreNotificationData(ctx, data))
+		}
+
+		before := uuid.New()
+		insert(before, `{"body":{"series":[{"startdate":1000,"enddate":2000,"state":1}]}}`)
+		matching := uuid.New()
+		insert(matching, `{"body":{"series":[{"startdate":3500,"enddate":3800,"state":1}]}}`)
+		after := uuid.New()
+		insert(after, `{"body":{"series":[{"startdate":5000,"enddate":6000,"state":1}]}}`)
+
+		rows, err := repo.GetNotificationDataByAccountAndServiceAndOverlappingWindow(
+			ctx, accountUUID, subscription.NotificationDataServiceSleepv2Get, 3000, 4000,
+		)
+		require.NoError(t, err)
+		require.Len(t, rows, 1, "only the row whose segment overlaps [3000,4000] should be returned")
+		require.Equal(t, matching, rows[0].NotificationUUID())
+	})
 }
+
+func ptrTimeAdapter(t time.Time) *time.Time { return &t }

--- a/pkg/withoutings/domain/subscription/subscriptionrepo.go
+++ b/pkg/withoutings/domain/subscription/subscriptionrepo.go
@@ -35,4 +35,5 @@ type Repo interface {
 	GetNotificationDataByNotificationUUID(ctx context.Context, notificationUUID uuid.UUID) ([]*NotificationData, error)
 	GetNotificationDataByAccountUUIDAndService(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService) ([]*NotificationData, error)
 	GetNotificationDataByAccountAndServiceAndSeriesStartdate(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService, startdate int64) (*NotificationData, error)
+	GetNotificationDataByAccountAndServiceAndOverlappingWindow(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService, windowStart, windowEnd int64) ([]*NotificationData, error)
 }

--- a/pkg/withoutings/domain/subscription/subscriptionrepo_mock.go
+++ b/pkg/withoutings/domain/subscription/subscriptionrepo_mock.go
@@ -396,6 +396,92 @@ func (_c *MockRepo_GetNotificationByUUID_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
+// GetNotificationDataByAccountAndServiceAndOverlappingWindow provides a mock function for the type MockRepo
+func (_mock *MockRepo) GetNotificationDataByAccountAndServiceAndOverlappingWindow(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService, windowStart int64, windowEnd int64) ([]*NotificationData, error) {
+	ret := _mock.Called(ctx, accountUUID, service, windowStart, windowEnd)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNotificationDataByAccountAndServiceAndOverlappingWindow")
+	}
+
+	var r0 []*NotificationData
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, NotificationDataService, int64, int64) ([]*NotificationData, error)); ok {
+		return returnFunc(ctx, accountUUID, service, windowStart, windowEnd)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, NotificationDataService, int64, int64) []*NotificationData); ok {
+		r0 = returnFunc(ctx, accountUUID, service, windowStart, windowEnd)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*NotificationData)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, NotificationDataService, int64, int64) error); ok {
+		r1 = returnFunc(ctx, accountUUID, service, windowStart, windowEnd)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepo_GetNotificationDataByAccountAndServiceAndOverlappingWindow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNotificationDataByAccountAndServiceAndOverlappingWindow'
+type MockRepo_GetNotificationDataByAccountAndServiceAndOverlappingWindow_Call struct {
+	*mock.Call
+}
+
+// GetNotificationDataByAccountAndServiceAndOverlappingWindow is a helper method to define mock.On call
+//   - ctx context.Context
+//   - accountUUID uuid.UUID
+//   - service NotificationDataService
+//   - windowStart int64
+//   - windowEnd int64
+func (_e *MockRepo_Expecter) GetNotificationDataByAccountAndServiceAndOverlappingWindow(ctx interface{}, accountUUID interface{}, service interface{}, windowStart interface{}, windowEnd interface{}) *MockRepo_GetNotificationDataByAccountAndServiceAndOverlappingWindow_Call {
+	return &MockRepo_GetNotificationDataByAccountAndServiceAndOverlappingWindow_Call{Call: _e.mock.On("GetNotificationDataByAccountAndServiceAndOverlappingWindow", ctx, accountUUID, service, windowStart, windowEnd)}
+}
+
+func (_c *MockRepo_GetNotificationDataByAccountAndServiceAndOverlappingWindow_Call) Run(run func(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService, windowStart int64, windowEnd int64)) *MockRepo_GetNotificationDataByAccountAndServiceAndOverlappingWindow_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uuid.UUID
+		if args[1] != nil {
+			arg1 = args[1].(uuid.UUID)
+		}
+		var arg2 NotificationDataService
+		if args[2] != nil {
+			arg2 = args[2].(NotificationDataService)
+		}
+		var arg3 int64
+		if args[3] != nil {
+			arg3 = args[3].(int64)
+		}
+		var arg4 int64
+		if args[4] != nil {
+			arg4 = args[4].(int64)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepo_GetNotificationDataByAccountAndServiceAndOverlappingWindow_Call) Return(notificationDatas []*NotificationData, err error) *MockRepo_GetNotificationDataByAccountAndServiceAndOverlappingWindow_Call {
+	_c.Call.Return(notificationDatas, err)
+	return _c
+}
+
+func (_c *MockRepo_GetNotificationDataByAccountAndServiceAndOverlappingWindow_Call) RunAndReturn(run func(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService, windowStart int64, windowEnd int64) ([]*NotificationData, error)) *MockRepo_GetNotificationDataByAccountAndServiceAndOverlappingWindow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNotificationDataByAccountAndServiceAndSeriesStartdate provides a mock function for the type MockRepo
 func (_mock *MockRepo) GetNotificationDataByAccountAndServiceAndSeriesStartdate(ctx context.Context, accountUUID uuid.UUID, service NotificationDataService, startdate int64) (*NotificationData, error) {
 	ret := _mock.Called(ctx, accountUUID, service, startdate)

--- a/pkg/withoutings/port/sleep_session.go
+++ b/pkg/withoutings/port/sleep_session.go
@@ -111,16 +111,20 @@ func buildSleepSessionView(
 	view.Found = true
 	populateSummary(ctx, &view, summary)
 
-	// Pull all Sleep v2 - Get rows for the account; segments overlapping the
-	// session window contribute to the charts. Withings webhooks can deliver
-	// data spanning multiple sessions, so we filter inside.
-	getRows, err := repo.GetNotificationDataByAccountUUIDAndService(ctx, accountUUID, subscription.NotificationDataServiceSleepv2Get)
+	sessionStart := int64(summary.Startdate)
+	sessionEnd := int64(summary.Enddate)
+
+	// Pull only the Sleep v2 - Get rows whose body.series contains at least
+	// one segment overlapping the session window. Filtering in SQL avoids
+	// transferring (and Go-unmarshalling) every stored Get blob — each row is
+	// hundreds of KB once a user has months of webhook history.
+	getRows, err := repo.GetNotificationDataByAccountAndServiceAndOverlappingWindow(
+		ctx, accountUUID, subscription.NotificationDataServiceSleepv2Get, sessionStart, sessionEnd,
+	)
 	if err != nil {
 		return view, fmt.Errorf("get sleep-get rows: %w", err)
 	}
 
-	sessionStart := int64(summary.Startdate)
-	sessionEnd := int64(summary.Enddate)
 	var segments []withings.SleepGetEntry
 	seen := make(map[string]bool)
 	for _, row := range getRows {


### PR DESCRIPTION
## Summary
The detail page was fetching every stored \`Sleep v2 - Get\` row for the account and JSON-unmarshalling each one to find segments overlapping the session window. With months of nightly webhook history that's hundreds of rows × tens of KB of JSON per request — a real user (me) saw the page take **11-13s in prod** with occasional 502s from the upstream Caddy proxy.

This pushes the overlap filter into Postgres via \`EXISTS\` over \`jsonb_array_elements(body.series)\`. The new query \`GetNotificationDataByAccountAndServiceAndOverlappingWindow\` returns only the rows whose \`body.series\` contains at least one segment with \`startdate < window_end AND enddate > window_start\`. Rows that can't contribute are never transferred to Go and never unmarshalled.

No schema migration; uses existing \`(account_uuid, service, fetched_at)\` B-tree from #9 to narrow the candidate set, then PG evaluates the EXISTS per row.

## Test plan
- [x] Adapter test (\`subscription_pg_repo_test.go\`): three Get rows (strictly-before, overlapping, strictly-after); only the overlapping one is returned.
- [x] Existing \`TestSleepSessionPage\` integration test continues to pass.
- [x] \`PGPORT=54329 go test ./... -count=1\` — clean.
- [ ] Manual prod verification once deployed.

## Note on the master \`-race\` flake
Running the full suite under \`-race\` locally trips a panic in \`worker.Work\` when the test cancels the worker context — \`router.Run\` errors out with "could not begin transaction: ... operation was canceled" and we panic on the error. This reproduces on \`master\` too (post-#11 watermill upgrade) and is **not** introduced by this PR. Filing as a residual to handle separately — the worker should treat \`ctx.Err()\` as a clean shutdown rather than panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)